### PR TITLE
V1.5定版

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,14 +1,14 @@
 DRIVERNAME := wch
-all:	modules 
+all : modules
 
-install: modules
+install : modules
 	mkdir -p /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial
 	cp -f ./$(DRIVERNAME).ko /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial
 	depmod -a
 
 ifneq ($(KERNELRELEASE),)
 obj-m += $(DRIVERNAME).o
-$(DRIVERNAME)-y := wch_main.o wch_devtable.o wch_serial.o
+$(DRIVERNAME)-y := wch_devtable.o wch_serial.o wch_main.o
 else
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD	:= $(shell pwd)
@@ -17,6 +17,6 @@ modules:
 	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
 
 clean:
-	rm -rf *.mk .tmp_versions Module.symvers *.mod.c *.o *.ko .*.cmd Module.markers modules.order
+	rm -rf *.mk .tmp_versions Module.symvers *.mod.c *.o *.ko *.cmd Module.markers modules.order
 	rm -f /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial/$(DRIVERNAME).ko
-endif																																																																																																																																																			
+endif

--- a/driver/wch_common.h
+++ b/driver/wch_common.h
@@ -105,8 +105,8 @@
 /*******************************************************
 WCH driver information
 *******************************************************/
-#define WCH_DRIVER_VERSION 		"1.13"
-#define WCH_DRIVER_DATE 		"2021/04/09"
+#define WCH_DRIVER_VERSION 		"1.14"
+#define WCH_DRIVER_DATE 		"2021/04/19"
 #define WCH_DRIVER_AUTHOR 		"WCH GROUP"
 #define WCH_DRIVER_DESC 		"WCH Multi-I/O Board Driver Module"
 

--- a/driver/wch_common.h
+++ b/driver/wch_common.h
@@ -105,8 +105,8 @@
 /*******************************************************
 WCH driver information
 *******************************************************/
-#define WCH_DRIVER_VERSION 		"1.14"
-#define WCH_DRIVER_DATE 		"2021/04/19"
+#define WCH_DRIVER_VERSION 		"1.15"
+#define WCH_DRIVER_DATE 		"2021/05/07"
 #define WCH_DRIVER_AUTHOR 		"WCH GROUP"
 #define WCH_DRIVER_DESC 		"WCH Multi-I/O Board Driver Module"
 

--- a/driver/wch_main.c
+++ b/driver/wch_main.c
@@ -10,7 +10,7 @@
  * (at your option) any later version.
  *
  *
- * Version: V1.13
+ * Version: V1.14
  *
  * Update Log:
  * V1.00 - initial version
@@ -19,6 +19,7 @@
  * V1.12 - fixed modem signals support
  * V1.13 - added automatic frequency multiplication when using baud rates higher than 115200bps
  		 - added mutex protect in uart send process
+ * V1.14 - optimized the processing of serial ports in interruption
  */
 
 #include "wch_common.h"
@@ -882,7 +883,7 @@ ch365_32s_test(
 int
 wch_register_irq(
 	void
-	) // \C7\EB\C7\F3\D6ж\CF
+	)
 {
 	struct wch_board *sb = NULL;
 	int status = 0;
@@ -964,7 +965,7 @@ wch_iounmap(
 void
 wch_release_irq(
 	void
-	) // \CAͷ\C5\D6ж\CF
+	)
 {
 	struct wch_board *sb = NULL;
     int i;
@@ -1101,20 +1102,18 @@ void
 __exit
 wch_exit(
 	void
-	) // ж\D4\D8ģ\BF\E9
+	)
 {
 	printk("\n\n");
 	printk("====================  WCH Device Driver Module Uninstall  ====================\n");
 	printk("\n");
 
 	wch_ser_unregister_ports(&wch_ser_reg);
-printk("***********wch_ser_unregister_ports***************\n");
+	printk("***********wch_ser_unregister_ports***************\n");
 	wch_ser_unregister_driver(&wch_ser_reg);
-printk("***********wch_ser_unregister_driver_success***********\n");
+	printk("***********wch_ser_unregister_driver_success***********\n");
 	wch_iounmap();
-printk("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
 	wch_release_irq();
-
 	printk("WCH Info : Unload WCH Multi-I/O Board Driver Module Done.\n");
 	printk("================================================================================\n");
 }

--- a/driver/wch_main.c
+++ b/driver/wch_main.c
@@ -1,16 +1,13 @@
 /*
- * WCH Multi-I/O Board Device Driver  - Copyright (C) 2020 WCH Corporation.
- * Author: TECH39 <zhangj@wch.cn>
+ * PCI/PCIE to serial driver for ch351/352/353/355/356/357/358/359/382/384, etc.
  *
- * PCI/PCIE to uart driver for ch351/352/353/355/356/357/358/359/382/384
+ * Copyright (C) 2021 WCH Corporation.
+ * Author: TECH39 <zhangj@wch.cn>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- *
- *
- * Version: V1.14
  *
  * Update Log:
  * V1.00 - initial version
@@ -20,6 +17,7 @@
  * V1.13 - added automatic frequency multiplication when using baud rates higher than 115200bps
  		 - added mutex protect in uart send process
  * V1.14 - optimized the processing of serial ports in interruption
+ * V1.15 - added support for non-standard baud rate
  */
 
 #include "wch_common.h"
@@ -619,11 +617,11 @@ wch_ser_port_table_init(
 				sp->port.uartclk = sp->port.baud_base * 16;
 				if (ch365_32s)
 				{
-					sp->port.iotype = WCH_UPIO_MEM; // MEM\B7\C3\CE\CA
+					sp->port.iotype = WCH_UPIO_MEM;
 				}
 				else
 				{
-					sp->port.iotype = WCH_UPIO_PORT; // IO\B7\C3\CE\CA
+					sp->port.iotype = WCH_UPIO_PORT;
 				}
 
 				sp->port.flags = ASYNC_SHARE_IRQ;
@@ -1047,21 +1045,21 @@ wch_init(
 	}
 	printk("------------------->ser port table init success\n");
 
-	status = wch_register_irq(); // \C7\EB\C7\F3\D6ж\CF
+	status = wch_register_irq();
 	if (status != 0)
 	{
 		goto step1_fail;
 	}
 	printk("------------------->pci register irq success\n");
 
-	status = wch_ser_register_driver(&wch_ser_reg); // ע\B2\E1\C7\FD\B6\AF
+	status = wch_ser_register_driver(&wch_ser_reg);
 	if (status != 0)
 	{
 		goto step2_fail;
 	}
 	printk("------------------->ser register driver success\n");
 
-   	status = wch_ser_register_ports(&wch_ser_reg); // ע\B2\E1\B6˿\DA
+   	status = wch_ser_register_ports(&wch_ser_reg);
     if (status != 0)
     {
         goto step3_fail;


### PR DESCRIPTION
增加支持非标准波特率，使用非标准波特率时建议通过波特率计算公式明确当前硬件是否支持目标波特率，具体计算方法见芯片手册。