### PR TITLE
V1.6 定版，更新README说明文档，修复串口时钟2倍频下波特率计算的Bug。

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Description:
 
 Note:  
 
- 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the number in array "wch_pci_board_conf" in wch_devtable.c, at about line 321 which relates to CH384_28S, modify the number 28 to the actual amount of serial ports.
+ 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the maximum uart amount varible "PCIE_UART_MAX" in wch_devtable.c at about line 3, modify the number 28 to the actual amount of serial ports.
 
  2. In this driver, the 22.1184M frequency is used to calculate the serial port baud rate by default. If other baud rates are required, the hardware needs to use other frequency crystal, and modify the crystal frequency variable "CRYSTAL_FREQ" defined in common.h at about line 258. 
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # ch35_38x_linux serial driver
+
 Description:  
 	This driver supports pci to uart chips ch351/ch352/ch353/ch355/ch356/ch357/ch358/ch359, pcie to uart chips ch382/ch384.  
-	In fact the chip types above were supported by 8250_pci and parport_serial driver, you can type "dmesg | grep ttyS" to find related tty devices.  
+	In fact most chip types above were supported by 8250_pci and parport_serial driver, you can type "dmesg | grep ttyS" to find related tty devices.  
 	Also you can use this specific driver, the tty devices are named "ttyWCHx".  
 
-1. open "Terminal"
-
-2. cd "driver" directory
-
-3. compile the driver using "make", you will see the module "wch.ko" if successful
-
-4. "insmod wch.ko" to load the driver dynamically
-
-5. "make install" to make the driver work permanently
-
-6. you can refer to the link below to acquire uart application, you can use gcc or Cross-compile with cross-gcc
+1. Open "Terminal"
+2. Switch to "driver" directory
+3. Compile the driver using "make", you will see the module "wch.ko" if successful
+4. Type "sudo make load" or "sudo insmod wch.ko" to load the driver dynamically
+5. Type "sudo make unload" or "sudo rmmod wch.ko" to unload the driver
+6. Type "sudo make install" to make the driver work permanently
+7. Type "sudo make uninstall" to remove the driver
+8. You can refer to the link below to acquire uart application, you can use gcc or Cross-compile with cross-gcc
    https://github.com/WCHSoftGroup/tty_uart
 
 Note:  
-	If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  
-	You can modify the number in array "wch_pci_board_conf" in wch_devtable.c, at about line 321 which relates to CH384_28S, modify the number 28 to the actual amount of serial ports.
+
+ 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the number in array "wch_pci_board_conf" in wch_devtable.c, at about line 321 which relates to CH384_28S, modify the number 28 to the actual amount of serial ports.
+
+ 2. In this driver, the 22.1184M frequency is used to calculate the serial port baud rate by default. If other baud rates are required, the hardware needs to use other frequency crystal, and modify the crystal frequency variable "CRYSTAL_FREQ" defined in common.h at about line 258. 
+
+ 3. The internal reference clock of the serial port(uartclk) is equal to 1/12 or twice the frequency of the external crystal. Serial port baud rate = uartclk / 16 / 16-bit baud rate divisor reg. When the reg is equal to 1, the maximum serial baud rate supported by the crystal can be calculated. Exp:
+
+    when 22.1184MHz crystal is selected, baud rate(max) = 22.1184M * 2 / 16 / 1 = 2.7648Mbps.
+
+    when 64MHz crystal is selected, baud rate(max) = 64M * 2 / 16 / 1 = 8Mbps.
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note:
 
  1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the uart amount variable "PCIE_UART_MAX" defined in wch_devtable.c at about line 3, modify the number 28 to the actual amount of serial ports.
 
- 2. In this driver, the 22.1184M frequency is used to calculate the serial port baud rate by default. If other baud rates are required, the hardware needs to use other frequency crystal, and modify the crystal frequency variable "CRYSTAL_FREQ" defined in common.h at about line 258. 
+ 2. In this driver, the 22.1184M frequency is used to calculate the serial port baud rate by default. If other baud rates are required, the hardware needs to use other frequency crystal, and modify the crystal frequency variable "CRYSTAL_FREQ" defined in common.h at about line 255. 
 
  3. The internal reference clock of the serial port(uartclk) is equal to 1/12 or twice the frequency of the external crystal. Serial port baud rate = uartclk / 16 / 16-bit baud rate divisor reg. When the reg is equal to 1, the maximum serial baud rate supported by the crystal can be calculated. Exp:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Description:
 
 Note:  
 
- 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the maximum uart amount varible "PCIE_UART_MAX" in wch_devtable.c at about line 3, modify the number 28 to the actual amount of serial ports.
+ 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the number in array "wch_pci_board_conf" in wch_devtable.c, at about line 321 which relates to CH384_28S, modify the number 28 to the actual amount of serial ports.
 
  2. In this driver, the 22.1184M frequency is used to calculate the serial port baud rate by default. If other baud rates are required, the hardware needs to use other frequency crystal, and modify the crystal frequency variable "CRYSTAL_FREQ" defined in common.h at about line 258. 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Description:
 
 Note:  
 
- 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the number in array "wch_pci_board_conf" in wch_devtable.c, at about line 321 which relates to CH384_28S, modify the number 28 to the actual amount of serial ports.
+ 1. If you are using multi-ports card such as CH384 + CH438 * n to achieve 12/16/20 serial ports etc.  You can modify the uart amount variable "PCIE_UART_MAX" defined in wch_devtable.c at about line 3, modify the number 28 to the actual amount of serial ports.
 
  2. In this driver, the 22.1184M frequency is used to calculate the serial port baud rate by default. If other baud rates are required, the hardware needs to use other frequency crystal, and modify the crystal frequency variable "CRYSTAL_FREQ" defined in common.h at about line 258. 
 

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -12,7 +12,7 @@ modules:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 
 clean:
-	rm -rf *.mk .tmp_versions Module.symvers *.mod.c *.o *.ko *.cmd Module.markers modules.order
+	rm -rf *.mk .tmp_versions Module.symvers *.mod.c *.o *.ko .wch* Module.markers modules.order
 load:
 	insmod $(DRIVERNAME).ko
 unload:

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,22 +1,29 @@
 DRIVERNAME := wch
 all : modules
 
-install : modules
-	mkdir -p /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial
-	cp -f ./$(DRIVERNAME).ko /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial
-	depmod -a
-
 ifneq ($(KERNELRELEASE),)
 obj-m += $(DRIVERNAME).o
 $(DRIVERNAME)-y := wch_devtable.o wch_serial.o wch_main.o
 else
-KDIR := /lib/modules/$(shell uname -r)/build
+KERNELDIR := /lib/modules/$(shell uname -r)/build
 PWD	:= $(shell pwd)
 
 modules:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 
 clean:
 	rm -rf *.mk .tmp_versions Module.symvers *.mod.c *.o *.ko *.cmd Module.markers modules.order
+load:
+	insmod $(DRIVERNAME).ko
+unload:
+	rmmod $(DRIVERNAME)
+install : modules
+	mkdir -p /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial
+	cp -f ./$(DRIVERNAME).ko /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial
+	depmod -a
+uninstall:
 	rm -f /lib/modules/$(shell uname -r)/kernel/drivers/tty/serial/$(DRIVERNAME).ko
+	rm -f /lib/modules/$(shell uname -r)/kernel/drivers/char/$(DRIVERNAME).ko
+	rm -f /lib/modules/$(shell uname -r)/misc/$(DRIVERNAME).ko
+	depmod -a
 endif

--- a/driver/wch_common.h
+++ b/driver/wch_common.h
@@ -121,8 +121,7 @@ WCH driver debug
 #define WCH_DBG_SERPORT 1
 
 #if WCH_DBG_SERIAL
-static
-void
+static void
 dbg_serial(
     const char *fmt,
     ...
@@ -136,7 +135,7 @@ dbg_serial(
 	vsprintf(&buffer[0], fmt, arglist);
 	va_end(arglist);
 	len = strlen(buffer);
-	for(i = 0 ; i < len; i++) {
+	for (i = 0 ; i < len; i++) {
 		outb(buffer[i], 0x3F8);
 		mdelay(1);
 	}
@@ -247,8 +246,6 @@ enum {
 #define WCH_SER_TOTAL_MAX 			0x100
 
 extern int wch_ser_port_total_cnt;
-
-
 
 /*******************************************************
  * uart information
@@ -488,7 +485,6 @@ struct wch_board {
 	int	(*ser_isr)(struct wch_board *, struct wch_ser_port *);
 };
 
-
 /*-------------------------------------------------------------------------------
 
  for wch_serial.c
@@ -567,9 +563,7 @@ struct wch_board {
 #define WCH_UIF_NORMAL_ACTIVE (1 << 29)
 #define WCH_UIF_INITIALIZED (1 << 31)
 
-
 #define WCH_ENABLE_MS(port, cflag) ((port)->flags & WCH_UPF_HARDPPS_CD || (cflag) & CRTSCTS || !((cflag) & CLOCAL))
-
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 #define WCH_SER_DEVNUM(x) ((x)->index)
@@ -687,7 +681,7 @@ ser_handle_break(
 {
 	struct ser_info *info = port->info;
 
-	if(info->flags & WCH_UPF_SAK) {
+	if (info->flags & WCH_UPF_SAK) {
 		do_SAK(info->tty);
 	}
 	return 0;
@@ -704,10 +698,10 @@ ser_handle_dcd_change(
 
 	port->icount.dcd++;
 
-	if(info->flags & WCH_UIF_CHECK_CD) {
-		if(status) {
+	if (info->flags & WCH_UIF_CHECK_CD) {
+		if (status) {
 			wake_up_interruptible(&info->open_wait);
-		} else if(info->tty) {
+		} else if (info->tty) {
 			tty_hangup(info->tty);
 		}
 	}
@@ -727,23 +721,23 @@ ser_insert_char(
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 13))
 	struct tty_struct *tty = port->info->tty;
 
-	if((status & port->ignore_status_mask & ~overrun) == 0) {
+	if ((status & port->ignore_status_mask & ~overrun) == 0) {
 		tty_insert_flip_char(tty, ch, flag);
 	}
 
-	if(status & ~port->ignore_status_mask & overrun) {
+	if (status & ~port->ignore_status_mask & overrun) {
 		tty_insert_flip_char(tty, 0, TTY_OVERRUN);
 	}
 #else
 	struct tty_port *tty = &port->state->port0;
 
-	if((status & port->ignore_status_mask & ~overrun) == 0) {
-		if(tty_insert_flip_char(tty, ch, flag) == 0)
+	if ((status & port->ignore_status_mask & ~overrun) == 0) {
+		if (tty_insert_flip_char(tty, ch, flag) == 0)
 			++port->icount.buf_overrun;
 	}
 
-	if(status & ~port->ignore_status_mask & overrun) {
-		if(tty_insert_flip_char(tty, 0, TTY_OVERRUN) == 0)
+	if (status & ~port->ignore_status_mask & overrun) {
+		if (tty_insert_flip_char(tty, 0, TTY_OVERRUN) == 0)
 			++port->icount.buf_overrun;
 	}
 #endif

--- a/driver/wch_common.h
+++ b/driver/wch_common.h
@@ -105,8 +105,8 @@
 /*******************************************************
 WCH driver information
 *******************************************************/
-#define WCH_DRIVER_VERSION 		"1.15"
-#define WCH_DRIVER_DATE 		"2021/05/07"
+#define WCH_DRIVER_VERSION 		"1.16"
+#define WCH_DRIVER_DATE 		"2021/06/26"
 #define WCH_DRIVER_AUTHOR 		"WCH GROUP"
 #define WCH_DRIVER_DESC 		"WCH Multi-I/O Board Driver Module"
 
@@ -124,9 +124,9 @@ WCH driver debug
 static
 void
 dbg_serial(
-	const char *fmt,
-	...
-	)
+    const char *fmt,
+    ...
+)
 {
 	char buffer[256];
 	int i, len;
@@ -136,8 +136,7 @@ dbg_serial(
 	vsprintf(&buffer[0], fmt, arglist);
 	va_end(arglist);
 	len = strlen(buffer);
-	for (i = 0 ; i < len; i++)
-	{
+	for(i = 0 ; i < len; i++) {
 		outb(buffer[i], 0x3F8);
 		mdelay(1);
 	}
@@ -254,6 +253,10 @@ extern int wch_ser_port_total_cnt;
 /*******************************************************
  * uart information
  *******************************************************/
+
+// external crystal freq
+#define CRYSTAL_FREQ						22118400
+
 
 // uart fifo info
 #define CH351_FIFOSIZE_16					16
@@ -480,7 +483,7 @@ struct wch_board {
 	unsigned int board_flag;
 
 	unsigned int vector_mask;
-    struct pci_board pb_info;
+	struct pci_board pb_info;
 	struct pci_dev *pdev;
 	int	(*ser_isr)(struct wch_board *, struct wch_ser_port *);
 };
@@ -616,7 +619,7 @@ struct ser_driver {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 	struct tty_driver *tty_driver;
 #else
-    struct tty_driver tty_driver;
+	struct tty_driver tty_driver;
 #endif
 
 };
@@ -679,13 +682,12 @@ struct ser_state {
 
 static inline int
 ser_handle_break(
-				 struct ser_port *port
-				 )
+    struct ser_port *port
+)
 {
 	struct ser_info *info = port->info;
 
-	if (info->flags & WCH_UPF_SAK)
-	{
+	if(info->flags & WCH_UPF_SAK) {
 		do_SAK(info->tty);
 	}
 	return 0;
@@ -694,22 +696,18 @@ ser_handle_break(
 
 static inline void
 ser_handle_dcd_change(
-					  struct ser_port *port,
-					  unsigned int status
-					  )
+    struct ser_port *port,
+    unsigned int status
+)
 {
 	struct ser_info *info = port->info;
 
 	port->icount.dcd++;
 
-	if (info->flags & WCH_UIF_CHECK_CD)
-	{
-		if (status)
-		{
+	if(info->flags & WCH_UIF_CHECK_CD) {
+		if(status) {
 			wake_up_interruptible(&info->open_wait);
-		}
-		else if (info->tty)
-		{
+		} else if(info->tty) {
 			tty_hangup(info->tty);
 		}
 	}
@@ -719,39 +717,35 @@ ser_handle_dcd_change(
 
 static inline void
 ser_insert_char(
-				struct ser_port *port,
-				unsigned int status,
-				unsigned int overrun,
-				unsigned int ch,
-				unsigned int flag
-				)
+    struct ser_port *port,
+    unsigned int status,
+    unsigned int overrun,
+    unsigned int ch,
+    unsigned int flag
+)
 {
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 13))
 	struct tty_struct *tty = port->info->tty;
 
-	if ((status & port->ignore_status_mask & ~overrun) == 0)
-    {
+	if((status & port->ignore_status_mask & ~overrun) == 0) {
 		tty_insert_flip_char(tty, ch, flag);
-    }
+	}
 
-	if (status & ~port->ignore_status_mask & overrun)
-    {
+	if(status & ~port->ignore_status_mask & overrun) {
 		tty_insert_flip_char(tty, 0, TTY_OVERRUN);
-    }
+	}
 #else
 	struct tty_port *tty = &port->state->port0;
 
-	if ((status & port->ignore_status_mask & ~overrun) == 0)
-    {
-		if (tty_insert_flip_char(tty, ch, flag) == 0)
+	if((status & port->ignore_status_mask & ~overrun) == 0) {
+		if(tty_insert_flip_char(tty, ch, flag) == 0)
 			++port->icount.buf_overrun;
-    }
+	}
 
-	if (status & ~port->ignore_status_mask & overrun)
-    {
-		if (tty_insert_flip_char(tty, 0, TTY_OVERRUN) == 0)
+	if(status & ~port->ignore_status_mask & overrun) {
+		if(tty_insert_flip_char(tty, 0, TTY_OVERRUN) == 0)
 			++port->icount.buf_overrun;
-    }
+	}
 #endif
 }
 

--- a/driver/wch_devtable.c
+++ b/driver/wch_devtable.c
@@ -1,5 +1,7 @@
 #include "wch_common.h"
 
+#define PCIE_UART_MAX 28
+
 struct pci_board wch_pci_board_conf[] = {
 	// NONE
 	{
@@ -318,7 +320,7 @@ struct pci_board wch_pci_board_conf[] = {
 		// VenID			DevID					 SubVenID				 SubSysID
 		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S,
 		// SerPort				IntrBar IntrOffset 	IntrOffset1	IntrOffset2	IntrOffset3	Name		 BoardFlag
-		28,		0,		0xE9,		0xE0,		0xE4,		0xE6,		"CH384_28S", BOARDFLAG_CH384_28_PORTS,
+		PCIE_UART_MAX,		0,		0xE9,		0xE0,		0xE4,		0xE6,		"CH384_28S", BOARDFLAG_CH384_28_PORTS,
 		{
 			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
 			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },

--- a/driver/wch_devtable.c
+++ b/driver/wch_devtable.c
@@ -1,7 +1,5 @@
 #include "wch_common.h"
 
-#define PCIE_UART_MAX 28
-
 struct pci_board wch_pci_board_conf[] = {
 	// NONE
 	{
@@ -320,7 +318,7 @@ struct pci_board wch_pci_board_conf[] = {
 		// VenID			DevID					 SubVenID				 SubSysID
 		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S,
 		// SerPort				IntrBar IntrOffset 	IntrOffset1	IntrOffset2	IntrOffset3	Name		 BoardFlag
-		PCIE_UART_MAX,		0,		0xE9,		0xE0,		0xE4,		0xE6,		"CH384_28S", BOARDFLAG_CH384_28_PORTS,
+		28,		0,		0xE9,		0xE0,		0xE4,		0xE6,		"CH384_28S", BOARDFLAG_CH384_28_PORTS,
 		{
 			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
 			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },

--- a/driver/wch_devtable.c
+++ b/driver/wch_devtable.c
@@ -1,17 +1,17 @@
 #include "wch_common.h"
 
 struct pci_board wch_pci_board_conf[] = {
-	// NONE 
-	{ 
-		// VenID	DevID	SubVenID	SubSysID	 
-		0x00,		0x00,	0x00,		0x00, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name	BoardFlag 
-		0x00,		0x00,	0x00,		0x00,		0x00,		0x00,		"none",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	'n',	-1,		0,		0,			-1,		0,		0,		NONE_BOARD	},					 
-		}, 
-	}, 
+	// NONE
+	{
+		// VenID	DevID	SubVenID	SubSysID
+		0x00,		0x00,	0x00,		0x00,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name	BoardFlag
+		0x00,		0x00,	0x00,		0x00,		0x00,		0x00,		"none",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	'n',	-1,		0,		0,			-1,		0,		0,		NONE_BOARD	},
+		},
+	},
 
 	// CH351_2S
 	{
@@ -27,378 +27,377 @@ struct pci_board wch_pci_board_conf[] = {
 	},
 
 	// CH352_2S
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH352_2S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH352_2S, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		0x02,		0x00,	0x00,		0x00,		0x00,		0x00,		"CH352_2S",	BOARDFLAG_REMAP, 
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH352_2S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH352_2S,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		0x02,		0x00,	0x00,		0x00,		0x00,		0x00,		"CH352_2S",	BOARDFLAG_REMAP,
 		{
 			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH352_2S	}, 
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH352_2S	},
 			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH352_2S	},
 		},
-	}, 
- 
-	// CH352_1S1P 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID	 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH352_1S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH352_1S1P, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag 
-		1,			0,		0x00,		0x00,		0x00,		0x00,		"CH352_1S1P",	BOARDFLAG_REMAP, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH352_1S1P	}, 
-		}, 
-	}, 
- 
-	// CH353_4S 
-	{				 
-		// VenID			DevID					SubVenID				SubSysID	 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH353_4S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH353_4S, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		4,			3,		0x0F,		0x00,		0x00,		0x00,		"CH353_4S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	}, 
- 
-		},	 
-	}, 
- 
-	// CH353_2S1P 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH353_2S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH353_2S1P, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		    BoardFlag 
-		2,			3,		0x0F,		0x00,		0x00,		0x00,		"CH353_2S1P",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1P  },					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1P  }, 
-		},	 
-	}, 
- 
-	// CH353_2S1PAR 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH353_2S1PAR, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH353_2S1PAR, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		    BoardFlag 
-		2,			3,		0x0F,		0x00,		0x00,		0x00,		"CH353_2S1PAR",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1PAR	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1PAR	}, 
-		},	 
 	},
- 
-	// CH355_4S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID	 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH355_4S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH355_4S, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		4,			4,		0x20,		0x00,		0x00,		0x00,		"CH355_4S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	}, 
- 
-		},	 
-	}, 
- 
-	// CH356_4S1P 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID	 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH356_4S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH356_4S1P, 
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		  BoardFlag 
-		4,			4,		 0x3F,		0x00,		0x00,		0x00,		"CH356_4S1P", BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	}, 
-		},	 
-	}, 
- 
-	// CH356_6S(CH356+CH432(1P)) 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH356_6S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH356_6S, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		6,			4,		0x3F,		0x00,		0x00,		0x00,		"CH356_6S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	}, 
-			{	's',	4,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	}, 
-			{	's',	4,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH356_6S	}, 
-		},	 
-	}, 
- 
-	// CH356_8S(CH356+CH432(2P)) 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH356_8S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH356_8S, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		8,			4,		0x3F,		0x00,		0x00,		0x00,		"CH356_8S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	4,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	4,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	4,		0x10,	8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-			{	's',	4,		0x18,	8,			-1,		0,		0,		WCH_BOARD_CH356_8S	}, 
-		},	 
-	}, 
- 
-	// CH357_4S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID					 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH357_4S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH357_4S,	 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		4,			4,		0x6F,		0x00,		0x00,		0x00,		"CH357_4S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	}, 
-		}, 
-	}, 
- 
-	// CH358_4S1P 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID	 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH358_4S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH358_4S1P, 
-		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag 
-		4,			4,		0x6F,		0x00,		0x00,		0x00,		"CH358_4S1P",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	}, 
-		},	 
-	}, 
- 
-	// CH358_8S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH358_8S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH358_8S,  
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag 
-		8,			4,		0x6F,		0x00,		0x00,		0x00,		"CH358_8S", BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},					 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-			{	's',	0,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-			{	's',	1,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-			{	's',	2,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-			{	's',	3,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	}, 
-		}, 
-	}, 
-		 
-	// CH359_16S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH359_16S,SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH359_16S, 
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name		BoardFlag 
-		16,			4,		0x6F,		0x00,		0x00,		0x00,		"CH359_16S",BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	0,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	1,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	2,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	3,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
- 
-			{	's',	4,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		16,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		32,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		48,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		24,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		40,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-			{	's',	4,		56,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	}, 
-		}, 
-	}, 
-	 
-	// CH382_2S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH382_2S,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH382_2S,  
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag 
-		2,			0,		0xE9,		0x00,		0x00,		0x00,		"CH382_2S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S	},					 
-			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S	}, 
-		}, 
-	}, 
- 
-	// CH382_2S1P 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH382_2S1P,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH382_2S1P,  
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name			BoardFlag 
-		2,			0,		0xE9,		0x00,		0x00,		0x00,		"CH382_2S1P",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S1P  },					 
-			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S1P  }, 
-		}, 
-	}, 
-	 
-	 
-	// CH384_4S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_4S,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH384_4S,  
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag 
-		4,			0,		0xE9,		0x00,		0x00,		0x00,		"CH384_4S",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S }, 
-			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S }, 
-			{	's',	0,		0xD0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S }, 
-			{	's',	0,		0xD8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S }, 
-		}, 
-	}, 
- 
-	// CH384_4S1P 
-	{ 
-		// VenID			DevID						SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_4S1P,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH384_4S1P,  
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name			BoardFlag 
-		4,			0,		0xE9,		0x00,		0x00,		0x00,		"CH384_4S1P",	BOARDFLAG_NONE, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  }, 
-			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  }, 
-			{	's',	0,		0xD0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  }, 
-			{	's',	0,		0xD8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  }, 
-		}, 
-	}, 
- 
-	// CH384_8S 
-	{ 
-		// VenID			DevID					SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_8S,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH384_8S,  
-		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name		BoardFlag 
-		8,			0,		0xE0,		0x00,		0x00,		0x00,		"CH384_8S",	BOARDFLAG_CH384_8_PORTS, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x10,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x20,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x30,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x18,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x28,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-			{	's',	0,		0x38,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	}, 
-		}, 
-	}, 
-	 
-	// CH384_28S 
-	{ 
-		// VenID			DevID					 SubVenID				 SubSysID 
-		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S,  
-		// SerPort				IntrBar IntrOffset 	IntrOffset1	IntrOffset2	IntrOffset3	Name		 BoardFlag 
-		28,		0,		0xE9,		0xE0,		0xE4,		0xE6,		"CH384_28S", BOARDFLAG_CH384_28_PORTS, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xD0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xD8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
- 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x10,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x20,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x30,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x18,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x28,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x38,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			 
-			{	's',	0,		0x40,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x50,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x60,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x70,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x48,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x58,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x68,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x78,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
- 
-			{	's',	0,		0x80,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x90,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xA0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xB0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x88,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0x98,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xA8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-			{	's',	0,		0xB8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 }, 
-		}, 
-	}, 
-	 
-	// CH365_32S 
-	{ 
-		// VenID			DevID					 SubVenID				SubSysID 
-		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH365_32S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH365_32S, 
-		// SerPort	IntrBar IntrOffset 	IntrOffset1  IntrOffset2 IntrOffset3 Name		  BoardFlag 
-		32,			1,		0x00,		0x00,		 0x00,		 0x00,		 "CH365_32S", BOARDFLAG_CH365_32_PORTS, 
-		{ 
-			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
- 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
- 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 }, 
-		}, 
+
+	// CH352_1S1P
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH352_1S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH352_1S1P,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag
+		1,			0,		0x00,		0x00,		0x00,		0x00,		"CH352_1S1P",	BOARDFLAG_REMAP,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH352_1S1P	},
+		},
+	},
+
+	// CH353_4S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH353_4S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH353_4S,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		4,			3,		0x0F,		0x00,		0x00,		0x00,		"CH353_4S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_4S	},
+
+		},
+	},
+
+	// CH353_2S1P
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH353_2S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH353_2S1P,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		    BoardFlag
+		2,			3,		0x0F,		0x00,		0x00,		0x00,		"CH353_2S1P",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1P  },
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1P  },
+		},
+	},
+
+	// CH353_2S1PAR
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH353_2S1PAR, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH353_2S1PAR,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		    BoardFlag
+		2,			3,		0x0F,		0x00,		0x00,		0x00,		"CH353_2S1PAR",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1PAR	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH353_2S1PAR	},
+		},
+	},
+
+	// CH355_4S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH355_4S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH355_4S,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		4,			4,		0x20,		0x00,		0x00,		0x00,		"CH355_4S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH355_4S	},
+
+		},
+	},
+
+	// CH356_4S1P
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH356_4S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH356_4S1P,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		  BoardFlag
+		4,			4,		 0x3F,		0x00,		0x00,		0x00,		"CH356_4S1P", BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_4S1P	},
+		},
+	},
+
+	// CH356_6S(CH356+CH432(1P))
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH356_6S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH356_6S,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		6,			4,		0x3F,		0x00,		0x00,		0x00,		"CH356_6S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},
+			{	's',	4,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},
+			{	's',	4,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH356_6S	},
+		},
+	},
+
+	// CH356_8S(CH356+CH432(2P))
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH356_8S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH356_8S,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		8,			4,		0x3F,		0x00,		0x00,		0x00,		"CH356_8S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	4,		0,		8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	4,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	4,		0x10,	8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+			{	's',	4,		0x18,	8,			-1,		0,		0,		WCH_BOARD_CH356_8S	},
+		},
+	},
+
+	// CH357_4S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH357_4S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH357_4S,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		4,			4,		0x6F,		0x00,		0x00,		0x00,		"CH357_4S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH357_4S	},
+		},
+	},
+
+	// CH358_4S1P
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH358_4S1P,	SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH358_4S1P,
+		// SerPort	IntrBar	IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag
+		4,			4,		0x6F,		0x00,		0x00,		0x00,		"CH358_4S1P",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_4S1P	},
+		},
+	},
+
+	// CH358_8S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH358_8S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH358_8S,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name		BoardFlag
+		8,			4,		0x6F,		0x00,		0x00,		0x00,		"CH358_8S", BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	0,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	1,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	2,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+			{	's',	3,		8,		8,			-1,		0,		0,		WCH_BOARD_CH358_8S	},
+		},
+	},
+
+	// CH359_16S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH359_16S, SUB_VENDOR_ID_WCH_PCI,	SUB_DEVICE_ID_WCH_CH359_16S,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name		BoardFlag
+		16,			4,		0x6F,		0x00,		0x00,		0x00,		"CH359_16S", BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	1,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	2,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	3,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	0,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	1,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	2,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	3,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+
+			{	's',	4,		0,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		16,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		32,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		48,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		8,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		24,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		40,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+			{	's',	4,		56,		8,			-1,		0,		0,		WCH_BOARD_CH359_16S	},
+		},
+	},
+
+	// CH382_2S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH382_2S,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH382_2S,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag
+		2,			0,		0xE9,		0x00,		0x00,		0x00,		"CH382_2S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S	},
+			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S	},
+		},
+	},
+
+	// CH382_2S1P
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH382_2S1P,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH382_2S1P,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name			BoardFlag
+		2,			0,		0xE9,		0x00,		0x00,		0x00,		"CH382_2S1P",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S1P  },
+			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH382_2S1P  },
+		},
+	},
+
+
+	// CH384_4S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_4S,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH384_4S,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3	Name			BoardFlag
+		4,			0,		0xE9,		0x00,		0x00,		0x00,		"CH384_4S",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S },
+			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S },
+			{	's',	0,		0xD0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S },
+			{	's',	0,		0xD8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S },
+		},
+	},
+
+	// CH384_4S1P
+	{
+		// VenID			DevID						SubVenID				SubSysID
+		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_4S1P,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH384_4S1P,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name			BoardFlag
+		4,			0,		0xE9,		0x00,		0x00,		0x00,		"CH384_4S1P",	BOARDFLAG_NONE,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  },
+			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  },
+			{	's',	0,		0xD0,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  },
+			{	's',	0,		0xD8,	8,			-1,		0,		0,		WCH_BOARD_CH384_4S1P  },
+		},
+	},
+
+	// CH384_8S
+	{
+		// VenID			DevID					SubVenID				SubSysID
+		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_8S,	SUB_VENDOR_ID_WCH_PCIE,	SUB_DEVICE_ID_WCH_CH384_8S,
+		// SerPort	IntrBar IntrOffset	IntrOffset1	IntrOffset2	IntrOffset3 Name		BoardFlag
+		8,			0,		0xE0,		0x00,		0x00,		0x00,		"CH384_8S",	BOARDFLAG_CH384_8_PORTS,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x10,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x20,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x30,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x18,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x28,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+			{	's',	0,		0x38,	8,			-1,		0,		0,		WCH_BOARD_CH384_8S	},
+		},
+	},
+
+	// CH384_28S
+	{
+		// VenID			DevID					 SubVenID				 SubSysID
+		VENDOR_ID_WCH_PCIE,	DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S,
+		// SerPort				IntrBar IntrOffset 	IntrOffset1	IntrOffset2	IntrOffset3	Name		 BoardFlag
+		28,		0,		0xE9,		0xE0,		0xE4,		0xE6,		"CH384_28S", BOARDFLAG_CH384_28_PORTS,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0xC0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xC8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xD0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xD8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x10,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x20,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x30,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x08,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x18,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x28,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x38,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+
+			{	's',	0,		0x40,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x50,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x60,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x70,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x48,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x58,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x68,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x78,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+
+			{	's',	0,		0x80,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x90,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xA0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xB0,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x88,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0x98,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xA8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+			{	's',	0,		0xB8,	8,			-1,		0,		0,		WCH_BOARD_CH384_28S	 },
+		},
+	},
+
+	// CH365_32S
+	{
+		// VenID			DevID					 SubVenID				SubSysID
+		VENDOR_ID_WCH_PCI,	DEVICE_ID_WCH_CH365_32S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH365_32S,
+		// SerPort	IntrBar IntrOffset 	IntrOffset1  IntrOffset2 IntrOffset3 Name		  BoardFlag
+		32,			1,		0x00,		0x00,		 0x00,		 0x00,		 "CH365_32S", BOARDFLAG_CH365_32_PORTS,
+		{
+			//	type	bar1	ofs1	len1		bar2	ofs2	len2	flags
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	0,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+			{	's',	0,		0x00,	8,			-1,		0,		0,		WCH_BOARD_CH365_32S	 },
+		},
 	},
 };
-

--- a/driver/wch_main.c
+++ b/driver/wch_main.c
@@ -1,7 +1,7 @@
 /*
  * PCI/PCIE to serial driver for ch351/352/353/355/356/357/358/359/382/384, etc.
  *
- * Copyright (C) 2021 WCH Corporation.
+ * Copyright (C) 2021 WCH.
  * Author: TECH39 <zhangj@wch.cn>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,7 @@
  		 - added mutex protect in uart send process
  * V1.14 - optimized the processing of serial ports in interruption
  * V1.15 - added support for non-standard baud rate
+ * V1.16 - fixed uart clock frequency multiplication bugs
  */
 
 #include "wch_common.h"
@@ -25,7 +26,7 @@
 MODULE_AUTHOR(WCH_DRIVER_AUTHOR);
 MODULE_DESCRIPTION(WCH_DRIVER_DESC);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,4,18))
-	MODULE_LICENSE("GPL");
+MODULE_LICENSE("GPL");
 #endif
 
 extern struct wch_board wch_board_table[WCH_BOARDS_MAX];
@@ -33,64 +34,64 @@ extern struct wch_ser_port wch_ser_table[WCH_SER_TOTAL_MAX + 1];
 extern unsigned char ch365_32s;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-	static struct pci_device_id wch_pci_board_id[] = {
-		{VENDOR_ID_WCH_CH351, DEVICE_ID_WCH_CH351_2S, SUB_VENDOR_ID_WCH_CH351, SUB_DEVICE_ID_WCH_CH351_2S, 0, 0, WCH_BOARD_CH351_2S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_2S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_2S, 0, 0, WCH_BOARD_CH352_2S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_1S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_1S1P, 0, 0, WCH_BOARD_CH352_1S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_4S, 0, 0, WCH_BOARD_CH353_4S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1P, 0, 0, WCH_BOARD_CH353_2S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1PAR, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1PAR, 0, 0, WCH_BOARD_CH353_2S1PAR},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH355_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH355_4S, 0, 0, WCH_BOARD_CH355_4S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_4S1P, 0, 0, WCH_BOARD_CH356_4S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_6S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_6S, 0, 0, WCH_BOARD_CH356_6S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_8S, 0, 0, WCH_BOARD_CH356_8S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH357_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH357_4S, 0, 0, WCH_BOARD_CH357_4S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_4S1P, 0, 0, WCH_BOARD_CH358_4S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_8S, 0, 0, WCH_BOARD_CH358_8S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH359_16S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH359_16S, 0, 0, WCH_BOARD_CH359_16S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S, 0, 0, WCH_BOARD_CH382_2S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S1P, 0, 0, WCH_BOARD_CH382_2S1P},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S, 0, 0, WCH_BOARD_CH384_4S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S1P, 0, 0, WCH_BOARD_CH384_4S1P},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_8S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_8S, 0, 0, WCH_BOARD_CH384_8S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S, 0, 0, WCH_BOARD_CH384_28S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH365_32S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH365_32S, 0, 0, WCH_BOARD_CH365_32S},
-		{0}
-	};
-	MODULE_DEVICE_TABLE(pci, wch_pci_board_id);
+static struct pci_device_id wch_pci_board_id[] = {
+	{VENDOR_ID_WCH_CH351, DEVICE_ID_WCH_CH351_2S, SUB_VENDOR_ID_WCH_CH351, SUB_DEVICE_ID_WCH_CH351_2S, 0, 0, WCH_BOARD_CH351_2S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_2S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_2S, 0, 0, WCH_BOARD_CH352_2S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_1S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_1S1P, 0, 0, WCH_BOARD_CH352_1S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_4S, 0, 0, WCH_BOARD_CH353_4S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1P, 0, 0, WCH_BOARD_CH353_2S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1PAR, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1PAR, 0, 0, WCH_BOARD_CH353_2S1PAR},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH355_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH355_4S, 0, 0, WCH_BOARD_CH355_4S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_4S1P, 0, 0, WCH_BOARD_CH356_4S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_6S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_6S, 0, 0, WCH_BOARD_CH356_6S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_8S, 0, 0, WCH_BOARD_CH356_8S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH357_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH357_4S, 0, 0, WCH_BOARD_CH357_4S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_4S1P, 0, 0, WCH_BOARD_CH358_4S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_8S, 0, 0, WCH_BOARD_CH358_8S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH359_16S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH359_16S, 0, 0, WCH_BOARD_CH359_16S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S, 0, 0, WCH_BOARD_CH382_2S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S1P, 0, 0, WCH_BOARD_CH382_2S1P},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S, 0, 0, WCH_BOARD_CH384_4S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S1P, 0, 0, WCH_BOARD_CH384_4S1P},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_8S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_8S, 0, 0, WCH_BOARD_CH384_8S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S, 0, 0, WCH_BOARD_CH384_28S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH365_32S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH365_32S, 0, 0, WCH_BOARD_CH365_32S},
+	{0}
+};
+MODULE_DEVICE_TABLE(pci, wch_pci_board_id);
 #else
-	struct wch_pci_info {
-		unsigned short vendor;
-		unsigned short device;
-		unsigned short subvendor;
-		unsigned short subdevice;
-		unsigned short driver_data;
-	};
+struct wch_pci_info {
+	unsigned short vendor;
+	unsigned short device;
+	unsigned short subvendor;
+	unsigned short subdevice;
+	unsigned short driver_data;
+};
 
-	static struct wch_pci_info wch_pci_board_id[] = {
-		{VENDOR_ID_WCH_CH351, DEVICE_ID_WCH_CH351_2S, SUB_VENDOR_ID_WCH_CH351, SUB_DEVICE_ID_WCH_CH351_2S, WCH_BOARD_CH351_2S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_2S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_2S, WCH_BOARD_CH352_2S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_1S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_1S1P, WCH_BOARD_CH352_1S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_4S, WCH_BOARD_CH353_4S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1P, WCH_BOARD_CH353_2S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1PAR, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1PAR, WCH_BOARD_CH353_2S1PAR},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH355_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH355_4S, WCH_BOARD_CH355_4S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_4S1P, WCH_BOARD_CH356_4S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_6S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_6S, WCH_BOARD_CH356_6S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_8S, WCH_BOARD_CH356_8S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH357_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH357_4S, WCH_BOARD_CH357_4S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_4S1P, WCH_BOARD_CH358_4S1P},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_8S, WCH_BOARD_CH358_8S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH359_16S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH359_16S, WCH_BOARD_CH359_16S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S, WCH_BOARD_CH382_2S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S1P, WCH_BOARD_CH382_2S1P},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S, WCH_BOARD_CH384_4S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S1P, WCH_BOARD_CH384_4S1P},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_8S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_8S, WCH_BOARD_CH384_8S},
-		{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S, WCH_BOARD_CH384_28S},
-		{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH365_32S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH365_32S, WCH_BOARD_CH365_32S},
-		{0}
-	};
+static struct wch_pci_info wch_pci_board_id[] = {
+	{VENDOR_ID_WCH_CH351, DEVICE_ID_WCH_CH351_2S, SUB_VENDOR_ID_WCH_CH351, SUB_DEVICE_ID_WCH_CH351_2S, WCH_BOARD_CH351_2S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_2S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_2S, WCH_BOARD_CH352_2S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH352_1S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH352_1S1P, WCH_BOARD_CH352_1S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_4S, WCH_BOARD_CH353_4S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1P, WCH_BOARD_CH353_2S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH353_2S1PAR, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH353_2S1PAR, WCH_BOARD_CH353_2S1PAR},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH355_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH355_4S, WCH_BOARD_CH355_4S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_4S1P, WCH_BOARD_CH356_4S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_6S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_6S, WCH_BOARD_CH356_6S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH356_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH356_8S, WCH_BOARD_CH356_8S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH357_4S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH357_4S, WCH_BOARD_CH357_4S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_4S1P, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_4S1P, WCH_BOARD_CH358_4S1P},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH358_8S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH358_8S, WCH_BOARD_CH358_8S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH359_16S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH359_16S, WCH_BOARD_CH359_16S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S, WCH_BOARD_CH382_2S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH382_2S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH382_2S1P, WCH_BOARD_CH382_2S1P},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S, WCH_BOARD_CH384_4S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_4S1P, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_4S1P, WCH_BOARD_CH384_4S1P},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_8S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_8S, WCH_BOARD_CH384_8S},
+	{VENDOR_ID_WCH_PCIE, DEVICE_ID_WCH_CH384_28S, SUB_VENDOR_ID_WCH_PCIE, SUB_DEVICE_ID_WCH_CH384_28S, WCH_BOARD_CH384_28S},
+	{VENDOR_ID_WCH_PCI, DEVICE_ID_WCH_CH365_32S, SUB_VENDOR_ID_WCH_PCI, SUB_DEVICE_ID_WCH_CH365_32S, WCH_BOARD_CH365_32S},
+	{0}
+};
 #endif
 
 struct wch_board wch_board_table[WCH_BOARDS_MAX];
@@ -100,96 +101,87 @@ int wch_ser_port_total_cnt;
 unsigned char ch365_32s = 0;
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,18))
-	static
-	irqreturn_t
-	wch_interrupt(
-		int irq,
-		void *dev_id
-		)
+static
+irqreturn_t
+wch_interrupt(
+    int irq,
+    void *dev_id
+)
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-	static
-	irqreturn_t
-	wch_interrupt(
-		int irq,
-		void *dev_id,
-		struct pt_regs *regs
-		)
+static
+irqreturn_t
+wch_interrupt(
+    int irq,
+    void *dev_id,
+    struct pt_regs *regs
+)
 #else
-	static
-	void
-	wch_interrupt(
-		int irq,
-		void *dev_id,
-		struct pt_regs *regs
-		)
+static
+void
+wch_interrupt(
+    int irq,
+    void *dev_id,
+    struct pt_regs *regs
+)
 #endif
 {
-    struct wch_ser_port *sp = NULL;
-    struct wch_board *sb = NULL;
-    int i;
-    int status = 0;
+	struct wch_ser_port *sp = NULL;
+	struct wch_board *sb = NULL;
+	int i;
+	int status = 0;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    int handled = IRQ_NONE;
+	int handled = IRQ_NONE;
 #endif
 
-    for (i = 0; i < WCH_BOARDS_MAX; i++)
-    {
-        if (dev_id == &(wch_board_table[i]))
-        {
-            sb = dev_id;
-            break;
-        }
-    }
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+		if(dev_id == &(wch_board_table[i])) {
+			sb = dev_id;
+			break;
+		}
+	}
 
-    if (i == WCH_BOARDS_MAX)
-    {
-        status = 1;
-    }
-
-    if (!sb)
-    {
+	if(i == WCH_BOARDS_MAX) {
 		status = 1;
-    }
+	}
 
-    if (sb->board_enum <= 0)
-    {
+	if(!sb) {
 		status = 1;
-    }
+	}
 
-    if (status != 0)
-    {
+	if(sb->board_enum <= 0) {
+		status = 1;
+	}
+
+	if(status != 0) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-        return handled;
+		return handled;
 #else
-        return;
+		return;
 #endif
-    }
+	}
 
-	if ((sb->ser_ports > 0) && (sb->ser_isr != NULL))
-	{
+	if((sb->ser_ports > 0) && (sb->ser_isr != NULL)) {
 		sp = &wch_ser_table[sb->ser_port_index];
 
-		if (!sp)
-		{
+		if(!sp) {
 			status = 1;
 		}
 
 		status = sb->ser_isr(sb, sp);
 	}
 
-    if (status != 0)
-    {
+	if(status != 0) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-        return handled;
+		return handled;
 #else
-        return;
+		return;
 #endif
-    }
+	}
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 	handled = IRQ_HANDLED;
-    return handled;
+	return handled;
 #endif
 }
 
@@ -197,32 +189,31 @@ unsigned char ch365_32s = 0;
 static
 int
 wch_pci_board_probe(
-	void
-	)
+    void
+)
 {
-    struct wch_board *sb;
-    struct pci_dev *pdev = NULL;
-    struct pci_dev *pdev_array[4] = {NULL, NULL, NULL, NULL};
+	struct wch_board *sb;
+	struct pci_dev *pdev = NULL;
+	struct pci_dev *pdev_array[4] = {NULL, NULL, NULL, NULL};
 
 	int wch_pci_board_id_cnt;
-    int table_cnt;
-    int board_cnt;
-    int i;
+	int table_cnt;
+	int board_cnt;
+	int i;
 	unsigned short int sub_device_id;
-    int status;
+	int status;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
 	// clear and init some variable
-    memset(wch_board_table, 0, WCH_BOARDS_MAX * sizeof(struct wch_board));
+	memset(wch_board_table, 0, WCH_BOARDS_MAX * sizeof(struct wch_board));
 
-    for (i = 0; i < WCH_BOARDS_MAX; i++)
-    {
-        wch_board_table[i].board_enum = -1;
-        wch_board_table[i].board_number = -1;
-    }
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+		wch_board_table[i].board_enum = -1;
+		wch_board_table[i].board_number = -1;
+	}
 
 	wch_pci_board_id_cnt = (sizeof(wch_pci_board_id) / sizeof(wch_pci_board_id[0])) - 1;
 
@@ -232,115 +223,94 @@ wch_pci_board_probe(
 	board_cnt = 0;
 	status = 0;
 
-    while (table_cnt < wch_pci_board_id_cnt)
-    {
+	while(table_cnt < wch_pci_board_id_cnt) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 		pdev = pci_get_device(wch_pci_board_id[table_cnt].vendor, wch_pci_board_id[table_cnt].device, pdev);
 #else
-        pdev = pci_find_device(wch_pci_board_id[table_cnt].vendor, wch_pci_board_id[table_cnt].device, pdev);
+		pdev = pci_find_device(wch_pci_board_id[table_cnt].vendor, wch_pci_board_id[table_cnt].device, pdev);
 #endif
-        if (pdev == NULL)
-        {
-           	table_cnt++;
-           	continue;
+		if(pdev == NULL) {
+			table_cnt++;
+			continue;
 		}
 
-        if ((table_cnt > 0) && ((pdev == pdev_array[0]) || (pdev == pdev_array[1]) || (pdev == pdev_array[2]) || (pdev == pdev_array[3])))
-        {
-            continue;
-        }
+		if((table_cnt > 0) && ((pdev == pdev_array[0]) || (pdev == pdev_array[1]) || (pdev == pdev_array[2]) || (pdev == pdev_array[3]))) {
+			continue;
+		}
 
-		if (wch_pci_board_id[table_cnt].driver_data == WCH_BOARD_CH365_32S)
-		{
+		if(wch_pci_board_id[table_cnt].driver_data == WCH_BOARD_CH365_32S) {
 			ch365_32s = 0x01;
 		}
 
 		pci_read_config_word(pdev, 0x2e, &sub_device_id);
 
-		if (ch365_32s)
-		{
+		if(ch365_32s) {
 
-		}
-		else
-		{
-			if (sub_device_id == 0)
-			{
+		} else {
+			if(sub_device_id == 0) {
 				printk("WCH Error: WCH Board (bus:%d device:%d), in configuration space,\n", pdev->bus->number, PCI_SLOT(pdev->devfn));
 				printk("           subdevice id isn't vaild.\n\n");
 				status = -EIO;
 				return status;
 			}
 
-			if (sub_device_id != wch_pci_board_id[table_cnt].subdevice)
-			{
+			if(sub_device_id != wch_pci_board_id[table_cnt].subdevice) {
 				continue;
 			}
 		}
-        if (pdev == NULL)
-        {
-            printk("WCH Error: PCI device object is an NULL pointer !\n\n");
-            status = -EIO;
-            return status;
-        }
-        else
-        {
+		if(pdev == NULL) {
+			printk("WCH Error: PCI device object is an NULL pointer !\n\n");
+			status = -EIO;
+			return status;
+		} else {
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3,8,0))
-    #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,4,3))
-            pci_disable_device(pdev);
-    #endif
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(2,4,3))
+			pci_disable_device(pdev);
 #endif
-            status = pci_enable_device(pdev);
+#endif
+			status = pci_enable_device(pdev);
 
-            if (status != 0)
-            {
-                printk("WCH Error: WCH Board Enable Fail !\n\n");
-                status = -ENXIO;
-                return status;
-            }
-        }
+			if(status != 0) {
+				printk("WCH Error: WCH Board Enable Fail !\n\n");
+				status = -ENXIO;
+				return status;
+			}
+		}
 
-        board_cnt++;
-        if (board_cnt > WCH_BOARDS_MAX)
-        {
-            printk("\n");
-            printk("WCH Error: WCH Driver Module Support Four Boards In Maximum !\n\n");
-            status = -ENOSPC;
-            return status;
-        }
+		board_cnt++;
+		if(board_cnt > WCH_BOARDS_MAX) {
+			printk("\n");
+			printk("WCH Error: WCH Driver Module Support Four Boards In Maximum !\n\n");
+			status = -ENOSPC;
+			return status;
+		}
 
-        sb = &wch_board_table[board_cnt - 1];
+		sb = &wch_board_table[board_cnt - 1];
 
-        pdev_array[board_cnt - 1] = pdev;
-        sb->pdev = pdev;
-        sb->bus_number = pdev->bus->number;
-        sb->dev_number = PCI_SLOT(pdev->devfn);
+		pdev_array[board_cnt - 1] = pdev;
+		sb->pdev = pdev;
+		sb->bus_number = pdev->bus->number;
+		sb->dev_number = PCI_SLOT(pdev->devfn);
 
-        sb->board_enum = (int)wch_pci_board_id[table_cnt].driver_data;
-        sb->pb_info = wch_pci_board_conf[sb->board_enum];
+		sb->board_enum = (int)wch_pci_board_id[table_cnt].driver_data;
+		sb->pb_info = wch_pci_board_conf[sb->board_enum];
 
 		sb->board_flag = sb->pb_info.board_flag;
 
-        sb->board_number = board_cnt - 1;
-    }
+		sb->board_number = board_cnt - 1;
+	}
 
-	// print info
-    if (board_cnt == 0)
-    {
-        printk("WCH Info : No WCH Multi-I/O Board Found !\n\n");
-        status = -ENXIO;
-        return status;
-    }
-	else
-	{
-		for (i = 0; i < WCH_BOARDS_MAX; i++)
-		{
+	if(board_cnt == 0) {
+		printk("WCH Info : No WCH Multi-I/O Board Found !\n\n");
+		status = -ENXIO;
+		return status;
+	} else {
+		for(i = 0; i < WCH_BOARDS_MAX; i++) {
 			sb = &wch_board_table[i];
-			if (sb->board_enum > 0)
-			{
+			if(sb->board_enum > 0) {
 				printk("\n");
-				if ((sb->pb_info.num_serport) > 0)
-				{
+				if((sb->pb_info.num_serport) > 0) {
 					printk("WCH Info : Found WCH %s Series Board (%dS),\n", sb->pb_info.board_name, sb->pb_info.num_serport);
 				}
 
@@ -349,55 +319,49 @@ wch_pci_board_probe(
 		}
 	}
 
-    return status;
+	return status;
 }
 
 static
 int
 wch_get_pci_board_conf(
-	void
-	)
+    void
+)
 {
-    struct wch_board *sb = NULL;
-    struct pci_dev *pdev = NULL;
-    int status = 0;
-    int i;
-    int j;
+	struct wch_board *sb = NULL;
+	struct pci_dev *pdev = NULL;
+	int status = 0;
+	int i;
+	int j;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-    for (i = 0; i < WCH_BOARDS_MAX; i++)
-    {
-        sb = &wch_board_table[i];
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+		sb = &wch_board_table[i];
 
-        if (sb->board_enum > 0)
-        {
+		if(sb->board_enum > 0) {
 			pdev = sb->pdev;
 			sb->ser_ports = sb->pb_info.num_serport;
 
 			wch_ser_port_total_cnt = wch_ser_port_total_cnt + sb->ser_ports;
 
 
-			if (wch_ser_port_total_cnt > WCH_SER_TOTAL_MAX)
-			{
+			if(wch_ser_port_total_cnt > WCH_SER_TOTAL_MAX) {
 				printk("WCH Error: Too much serial port, maximum %d ports can be supported !\n\n", WCH_SER_TOTAL_MAX);
 				status = -EIO;
 				return status;
 			}
 
 
-			for (j = 0; j < WCH_PCICFG_BAR_TOTAL; j++)
-			{
+			for(j = 0; j < WCH_PCICFG_BAR_TOTAL; j++) {
 				sb->bar_addr[j] = pci_resource_start(pdev, j);
 			}
 
-			if((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS)
-			{
+			if((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS) {
 				sb->board_membase = ioremap(sb->bar_addr[1], 4096);
-				if (!sb->board_membase)
-				{
+				if(!sb->board_membase) {
 					status = -EIO;
 					printk("WCH Error: ioremap failed !\n");
 					return status;
@@ -405,32 +369,31 @@ wch_get_pci_board_conf(
 			}
 
 			sb->irq = sb->pdev->irq;
-			if (sb->irq <= 0)
-			{
+			if(sb->irq <= 0) {
 				printk("WCH Error: WCH Board %s Series (bus:%d device:%d), in configuartion space, irq isn't valid !\n\n",
-					sb->pb_info.board_name,
-					sb->bus_number,
-					sb->dev_number
-					);
+				       sb->pb_info.board_name,
+				       sb->bus_number,
+				       sb->dev_number
+				      );
 
 				status = -EIO;
 				return status;
 			}
-        }
-    }
+		}
+	}
 
-    return status;
+	return status;
 }
 
 static
 int
 wch_assign_resource(
-	void
-	)
+    void
+)
 {
 	struct wch_board *sb = NULL;
 	struct wch_ser_port *sp = NULL;
-    int status = 0;
+	int status = 0;
 	int i;
 	int j;
 	int ser_n;
@@ -442,14 +405,11 @@ wch_assign_resource(
 
 	memset(wch_ser_table, 0, (WCH_SER_TOTAL_MAX + 1) * sizeof(struct wch_ser_port));
 
-	for (i = 0; i < WCH_BOARDS_MAX; i++)
-	{
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if (sb->board_enum > 0)
-		{
-			if (sb->ser_ports > 0)
-			{
+		if(sb->board_enum > 0) {
+			if(sb->ser_ports > 0) {
 				sb->vector_mask = 0;
 
 				// assign serial port resource
@@ -457,101 +417,69 @@ wch_assign_resource(
 
 				sp = &wch_ser_table[ser_n];
 
-				if (sp == NULL)
-				{
+				if(sp == NULL) {
 					status = -ENXIO;
 					printk("WCH Error: Serial port table address error !\n");
 					return status;
 				}
 
-				for (j = 0; j < sb->ser_ports; j++, ser_n++, sp++)
-				{
+				for(j = 0; j < sb->ser_ports; j++, ser_n++, sp++) {
 					sp->port.chip_flag = sb->pb_info.port[j].chip_flag;
 					sp->port.iobase = sb->bar_addr[sb->pb_info.port[j].bar1] + sb->pb_info.port[j].offset1;
-					if ((sb->board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP)
-					{
+					if((sb->board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP) {
 						sp->port.vector = 0;
-					}
-					else if((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS)
-					{
+					} else if((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) {
 						sp->port.chip_iobase = sb->bar_addr[sb->pb_info.port[j].bar1];
 						sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset;
-					}
-					else if((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)
-					{
+					} else if((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS) {
 						sp->port.chip_iobase = sb->bar_addr[sb->pb_info.port[j].bar1];
-						if (j >= 0 && j < 0x04)
-						{
+						if(j >= 0 && j < 0x04) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset;
-						}
-						else if (j >= 0x04 && j < 0x0C)
-						{
+						} else if(j >= 0x04 && j < 0x0C) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset_1;
-						}
-						else if (j >= 0x0C && j < 0x14)
-						{
+						} else if(j >= 0x0C && j < 0x14) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset_2;
-						}
-						else if (j >= 0x14 && j < 0x1C)
-						{
+						} else if(j >= 0x14 && j < 0x1C) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset_3;
-						}
-						else
-						{
+						} else {
 
 						}
-					}
-					else if((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS)
-					{
+					} else if((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS) {
 						sp->port.chip_iobase = sb->bar_addr[sb->pb_info.port[j].bar1];
 						sp->port.board_membase = sb->board_membase;
-						if (j >= 0 && j < 0x08)
-						{
-							if(j >=0 && j < 0x04)
-							{
+						if(j >= 0 && j < 0x08) {
+							if(j >= 0 && j < 0x04) {
 								sp->port.port_membase = sb->board_membase + 0x100 + j * 0x10;
 							}
-							if(j >=4 && j < 0x08)
-							{
+							if(j >= 4 && j < 0x08) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x08 + (j - 4) * 0x10;
 							}
 						}
-						if (j >= 0x08 && j < 0x10)
-						{
-							if(j >=0x08 && j < 0x0C)
-							{
+						if(j >= 0x08 && j < 0x10) {
+							if(j >= 0x08 && j < 0x0C) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x80 + (j - 0x08) * 0x10;
 							}
-							if(j >=0x0C && j < 0x10)
-							{
+							if(j >= 0x0C && j < 0x10) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x80 + 0x08 + (j - 0x0C) * 0x10;
 							}
 						}
-						if (j >= 0x10 && j < 0x18)
-						{
-							if(j >=0x10 && j < 0x14)
-							{
+						if(j >= 0x10 && j < 0x18) {
+							if(j >= 0x10 && j < 0x14) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x100 + (j - 0x10) * 0x10;
 							}
-							if(j >=0x14 && j < 0x18)
-							{
+							if(j >= 0x14 && j < 0x18) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x100 + 0x08 + (j - 0x14) * 0x10;
 							}
 						}
-						if (j >= 0x18 && j < 0x20)
-						{
-							if(j >=0x18 && j < 0x1C)
-							{
+						if(j >= 0x18 && j < 0x20) {
+							if(j >= 0x18 && j < 0x1C) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x180 + (j - 0x18) * 0x10;
 							}
-							if(j >=0x1C && j < 0x20)
-							{
+							if(j >= 0x1C && j < 0x20) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x180 + 0x08 + (j - 0x1C) * 0x10;
 							}
 						}
-					}
-					else
-					{
+					} else {
 						sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset;
 					}
 				}
@@ -567,12 +495,12 @@ wch_assign_resource(
 static
 int
 wch_ser_port_table_init(
-	void
-	)
+    void
+)
 {
 	struct wch_board *sb = NULL;
 	struct wch_ser_port *sp = NULL;
-    int status = 0;
+	int status = 0;
 	int i;
 	int j;
 	int n;
@@ -581,46 +509,38 @@ wch_ser_port_table_init(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for (i = 0; i < WCH_BOARDS_MAX; i++)
-	{
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if (sb == NULL)
-		{
+		if(sb == NULL) {
 			status = -ENXIO;
 			printk("WCH Error: Board table pointer error !\n");
 			return status;
 		}
 
-		if ((sb->board_enum > 0) && (sb->ser_ports > 0))
-		{
+		if((sb->board_enum > 0) && (sb->ser_ports > 0)) {
 			n = sb->ser_port_index;
 			sp = &wch_ser_table[n];
 
-			if (sp == NULL)
-			{
+			if(sp == NULL) {
 				status = -ENXIO;
 				printk("WCH Error: Serial port table pointer error !\n");
 				return status;
 			}
 
-			for (j = 0; j < sb->ser_ports; j++, n++, sp++)
-			{
+			for(j = 0; j < sb->ser_ports; j++, n++, sp++) {
 				sp->port.board_enum = sb->board_enum;
 				sp->port.bus_number = sb->bus_number;
 				sp->port.dev_number = sb->dev_number;
-				sp->port.baud_base = 115200;
+				sp->port.baud_base = CRYSTAL_FREQ / 12 / 16;
 				sp->port.pb_info = sb->pb_info;
 
 				sp->port.irq = sb->irq;
 				sp->port.line = n;
-				sp->port.uartclk = sp->port.baud_base * 16;
-				if (ch365_32s)
-				{
+				sp->port.uartclk = CRYSTAL_FREQ / 12;
+				if(ch365_32s) {
 					sp->port.iotype = WCH_UPIO_MEM;
-				}
-				else
-				{
+				} else {
 					sp->port.iotype = WCH_UPIO_PORT;
 				}
 
@@ -630,107 +550,74 @@ wch_ser_port_table_init(
 				spin_lock_init(&sp->port.lock);
 
 
-				if(sp->port.chip_flag == WCH_BOARD_CH351_2S)
-				{
+				if(sp->port.chip_flag == WCH_BOARD_CH351_2S) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH351_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH351_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH352_2S || sp->port.chip_flag == WCH_BOARD_CH352_1S1P)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH352_2S || sp->port.chip_flag == WCH_BOARD_CH352_1S1P) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH352_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH352_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH353_4S || sp->port.chip_flag == WCH_BOARD_CH353_2S1P || sp->port.chip_flag == WCH_BOARD_CH353_2S1PAR)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH353_4S || sp->port.chip_flag == WCH_BOARD_CH353_2S1P || sp->port.chip_flag == WCH_BOARD_CH353_2S1PAR) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH353_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH353_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH355_4S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH355_4S) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH355_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH355_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH356_4S1P || sp->port.chip_flag == WCH_BOARD_CH356_6S || sp->port.chip_flag == WCH_BOARD_CH356_8S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH356_4S1P || sp->port.chip_flag == WCH_BOARD_CH356_6S || sp->port.chip_flag == WCH_BOARD_CH356_8S) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH356_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH356_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH357_4S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH357_4S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH357_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH357_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH358_4S1P || sp->port.chip_flag == WCH_BOARD_CH358_8S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH358_4S1P || sp->port.chip_flag == WCH_BOARD_CH358_8S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH358_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH358_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH359_16S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH359_16S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH359_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH359_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH382_2S || sp->port.chip_flag == WCH_BOARD_CH382_2S1P)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH382_2S || sp->port.chip_flag == WCH_BOARD_CH382_2S1P) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH382_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH382_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH384_4S || sp->port.chip_flag == WCH_BOARD_CH384_4S1P)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH384_4S || sp->port.chip_flag == WCH_BOARD_CH384_4S1P) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH384_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH384_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH384_8S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH384_8S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH358_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH358_TRIGGER_LEVEL_SET;
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH384_28S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH384_28S) {
 					sp->port.type = PORT_SER_16750;
-					if(j >= 0 && j < 0x04)
-					{
+					if(j >= 0 && j < 0x04) {
 						sp->port.fifosize = CH384_FIFOSIZE_SET;
 						sp->port.rx_trigger = CH384_TRIGGER_LEVEL_SET;
-					}
-					else
-					{
+					} else {
 						sp->port.fifosize = CH358_FIFOSIZE_SET;
 						sp->port.rx_trigger = CH358_TRIGGER_LEVEL_SET;
 					}
-				}
-				else if (sp->port.chip_flag == WCH_BOARD_CH365_32S)
-				{
+				} else if(sp->port.chip_flag == WCH_BOARD_CH365_32S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH438_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH438_TRIGGER_LEVEL_SET;
-				}
-				else
-				{
+				} else {
 					sp->port.type = PORT_SER_16450;
 					sp->port.fifosize = DEFAULT_FIFOSIZE;
 					sp->port.rx_trigger = DEFAULT_TRIGGER_LEVEL;
 				}
 
 
-				if ((sb->pb_info.board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP)
-				{
+				if((sb->pb_info.board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP) {
 					sp->port.vector_mask = 0;
 					sp->port.port_flag = PORTFLAG_REMAP;
-				}
-				else
-				{
+				} else {
 					sp->port.vector_mask = sb->vector_mask;
 					sp->port.port_flag = PORTFLAG_NONE;
 				}
@@ -739,21 +626,19 @@ wch_ser_port_table_init(
 			}
 
 			sb->ser_isr = wch_ser_interrupt;
-		}
-		else
-		{
+		} else {
 			sb->ser_isr = NULL;
 		}
 	}
 
-    return status;
+	return status;
 }
 
 #if WCH_DBG
 void
 wch_debug(
-	void
-	) // \B5\F7\CA\D4
+    void
+) // \B5\F7\CA\D4
 {
 #if WCH_DBG_BOARD
 	struct wch_board *sb = NULL;
@@ -768,11 +653,9 @@ wch_debug(
 #if WCH_DBG_BOARD
 	printk("\n");
 	printk("======== board info ========\n");
-	for (i = 0; i < WCH_BOARDS_MAX; i++)
-	{
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
-		if (sb->board_enum != -1)
-		{
+		if(sb->board_enum != -1) {
 			printk(" name         : %s\n", sb->pb_info.board_name);
 			printk(" board_enum   : %d\n", sb->board_enum);
 			printk(" board_number : %d\n", sb->board_number);
@@ -795,11 +678,9 @@ wch_debug(
 #if WCH_DBG_SERPORT
 	printk("\n");
 	printk("======== serial info ========\n");
-	for (j = 0; j < wch_ser_port_total_cnt; j++)
-	{
+	for(j = 0; j < wch_ser_port_total_cnt; j++) {
 		sp = &wch_ser_table[j];
-		if (sp->port.iobase)
-		{
+		if(sp->port.iobase) {
 			printk(" number       : %d\n", j);
 			printk(" name         : %s\n", sp->port.pb_info.board_name);
 			printk(" iobase       : 0x%x\n", sp->port.iobase);
@@ -823,18 +704,16 @@ wch_debug(
 #if WCH_DBG_SERIAL
 void
 ch365_32s_test(
-	void
-	)
+    void
+)
 {
 	struct wch_board *sb = NULL;
 	int i;
 	dbg_serial("\n");
 	dbg_serial("======== board info ========\n");
-	for (i = 0; i < WCH_BOARDS_MAX; i++)
-	{
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
-		if (sb->board_enum != -1)
-		{
+		if(sb->board_enum != -1) {
 			dbg_serial(" ch438_1_uart0 LSR = %x\n", readb(sb->board_membase + 0x100 + 0x05));
 			dbg_serial(" ch438_1_uart1 LSR = %x\n", readb(sb->board_membase + 0x100 + 0x05 + 0x08));
 			dbg_serial(" ch438_1_uart2 LSR = %x\n", readb(sb->board_membase + 0x100 + 0x05 + 0x10));
@@ -880,8 +759,8 @@ ch365_32s_test(
 
 int
 wch_register_irq(
-	void
-	)
+    void
+)
 {
 	struct wch_board *sb = NULL;
 	int status = 0;
@@ -892,44 +771,42 @@ wch_register_irq(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for (i = 0; i < WCH_BOARDS_MAX; i++)
-	{
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if (sb == NULL)
-		{
+		if(sb == NULL) {
 			status = -ENXIO;
 			printk("WCH Error: Board table pointer error !\n");
 			return status;
 		}
 
-		if (sb->board_enum > 0)
-		{
+		if(sb->board_enum > 0) {
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,18))
 			status = request_irq(sb->irq, wch_interrupt, IRQF_SHARED, "wch", sb);
 #else
-            status = request_irq(sb->irq, wch_interrupt, SA_SHIRQ, "wch", sb);
+			status = request_irq(sb->irq, wch_interrupt, SA_SHIRQ, "wch", sb);
 #endif
 
-			if (status)
-			{
+			if(status) {
 				printk("WCH Error: WCH Multi-I/O %s Board(bus:%d device:%d), request\n", sb->pb_info.board_name, sb->bus_number, sb->dev_number);
 				printk("           IRQ %d fail, IRQ %d may be conflit with another device.\n", sb->irq, sb->irq);
 				return status;
 			}
 
 		}
-		if (ch365_32s)
-		{
+		if(ch365_32s) {
 			outb(inb(sb->bar_addr[0] + 0xF8) & 0xFE, sb->bar_addr[0] + 0xF8);
 			outb(((inb(sb->bar_addr[0] + 0xFA) & 0xFB) | 0x03), sb->bar_addr[0] + 0xFA); // set read/write plus width 240ns->120ns
 		}
 
-		if (((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
-			((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
+		if(((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
+		   ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
 			chip_iobase = sb->bar_addr[0];
-			if (chip_iobase)
+			if(chip_iobase) {
 				outb(inb(chip_iobase + 0xEB) | 0x02, chip_iobase + 0xEB);
+				/* set read/write plus width 120ns->210ns */
+				outb(inb(chip_iobase + 0xFA) | 0x10, chip_iobase + 0xFA);
+			}
 		}
 	}
 
@@ -938,64 +815,59 @@ wch_register_irq(
 
 void
 wch_iounmap(
-	void
-	) // \CAͷ\C5IO
+    void
+) // \CAͷ\C5IO
 {
 	struct wch_board *sb = NULL;
-    int i;
+	int i;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-    for (i = 0; i < WCH_BOARDS_MAX; i++)
-    {
-        sb = &wch_board_table[i];
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+		sb = &wch_board_table[i];
 
-        if (sb->board_enum > 0)
-        {
+		if(sb->board_enum > 0) {
 			iounmap(sb->board_membase);
-        }
-    }
+		}
+	}
 }
 
 
 void
 wch_release_irq(
-	void
-	)
+    void
+)
 {
 	struct wch_board *sb = NULL;
-    int i;
+	int i;
 	unsigned int chip_iobase;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-    for (i = 0; i < WCH_BOARDS_MAX; i++)
-    {
-        sb = &wch_board_table[i];
+	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+		sb = &wch_board_table[i];
 
-        if (sb->board_enum > 0)
-        {
-            free_irq(sb->irq, sb);
-        }
-		if (ch365_32s)
-		{
+		if(sb->board_enum > 0) {
+			free_irq(sb->irq, sb);
+		}
+		if(ch365_32s) {
 			outb(inb(sb->bar_addr[0] + 0xF8) | 0x01, sb->bar_addr[0] + 0xF8);
 		}
-		if (((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
-			((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
+		if(((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
+		   ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
 			chip_iobase = sb->bar_addr[0];
-			if (chip_iobase)
+			if(chip_iobase)
 				outb(inb(chip_iobase + 0xEB) & 0xFD, chip_iobase + 0xEB);
 		}
-    }
+	}
 }
 
 static struct ser_driver wch_ser_reg = {
-    .dev_name = "ttyWCH",
+	.dev_name = "ttyWCH",
 	.major = WCH_TTY_MAJOR,
 	.minor = 0,
 };
@@ -1004,8 +876,8 @@ static
 int
 __init
 wch_init(
-	void
-	)
+    void
+)
 {
 	int status = 0;
 
@@ -1019,51 +891,44 @@ wch_init(
 	wch_ser_port_total_cnt = 0;
 
 	status = wch_pci_board_probe();
-	if (status != 0)
-	{
+	if(status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci board probe success\n");
 	status = wch_get_pci_board_conf();
-	if (status != 0)
-	{
+	if(status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci board conf success\n");
 
 	status = wch_assign_resource();
-	if (status != 0)
-	{
+	if(status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci assign success\n");
 
 	status = wch_ser_port_table_init();
-	if (status != 0)
-	{
+	if(status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->ser port table init success\n");
 
 	status = wch_register_irq();
-	if (status != 0)
-	{
+	if(status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci register irq success\n");
 
 	status = wch_ser_register_driver(&wch_ser_reg);
-	if (status != 0)
-	{
+	if(status != 0) {
 		goto step2_fail;
 	}
 	printk("------------------->ser register driver success\n");
 
-   	status = wch_ser_register_ports(&wch_ser_reg);
-    if (status != 0)
-    {
-        goto step3_fail;
-    }
+	status = wch_ser_register_ports(&wch_ser_reg);
+	if(status != 0) {
+		goto step3_fail;
+	}
 
 
 #if WCH_DBG
@@ -1099,8 +964,8 @@ static
 void
 __exit
 wch_exit(
-	void
-	)
+    void
+)
 {
 	printk("\n\n");
 	printk("====================  WCH Device Driver Module Uninstall  ====================\n");

--- a/driver/wch_main.c
+++ b/driver/wch_main.c
@@ -101,23 +101,20 @@ int wch_ser_port_total_cnt;
 unsigned char ch365_32s = 0;
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,18))
-static
-irqreturn_t
+static irqreturn_t
 wch_interrupt(
     int irq,
     void *dev_id
 )
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-static
-irqreturn_t
+static irqreturn_t
 wch_interrupt(
     int irq,
     void *dev_id,
     struct pt_regs *regs
 )
 #else
-static
-void
+static void
 wch_interrupt(
     int irq,
     void *dev_id,
@@ -134,26 +131,26 @@ wch_interrupt(
 	int handled = IRQ_NONE;
 #endif
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
-		if(dev_id == &(wch_board_table[i])) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
+		if (dev_id == &(wch_board_table[i])) {
 			sb = dev_id;
 			break;
 		}
 	}
 
-	if(i == WCH_BOARDS_MAX) {
+	if (i == WCH_BOARDS_MAX) {
 		status = 1;
 	}
 
-	if(!sb) {
+	if (!sb) {
 		status = 1;
 	}
 
-	if(sb->board_enum <= 0) {
+	if (sb->board_enum <= 0) {
 		status = 1;
 	}
 
-	if(status != 0) {
+	if (status != 0) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 		return handled;
 #else
@@ -161,17 +158,17 @@ wch_interrupt(
 #endif
 	}
 
-	if((sb->ser_ports > 0) && (sb->ser_isr != NULL)) {
+	if ((sb->ser_ports > 0) && (sb->ser_isr != NULL)) {
 		sp = &wch_ser_table[sb->ser_port_index];
 
-		if(!sp) {
+		if (!sp) {
 			status = 1;
 		}
 
 		status = sb->ser_isr(sb, sp);
 	}
 
-	if(status != 0) {
+	if (status != 0) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 		return handled;
 #else
@@ -186,8 +183,7 @@ wch_interrupt(
 }
 
 
-static
-int
+static int
 wch_pci_board_probe(
     void
 )
@@ -210,7 +206,7 @@ wch_pci_board_probe(
 	// clear and init some variable
 	memset(wch_board_table, 0, WCH_BOARDS_MAX * sizeof(struct wch_board));
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		wch_board_table[i].board_enum = -1;
 		wch_board_table[i].board_number = -1;
 	}
@@ -223,42 +219,42 @@ wch_pci_board_probe(
 	board_cnt = 0;
 	status = 0;
 
-	while(table_cnt < wch_pci_board_id_cnt) {
+	while (table_cnt < wch_pci_board_id_cnt) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 		pdev = pci_get_device(wch_pci_board_id[table_cnt].vendor, wch_pci_board_id[table_cnt].device, pdev);
 #else
 		pdev = pci_find_device(wch_pci_board_id[table_cnt].vendor, wch_pci_board_id[table_cnt].device, pdev);
 #endif
-		if(pdev == NULL) {
+		if (pdev == NULL) {
 			table_cnt++;
 			continue;
 		}
 
-		if((table_cnt > 0) && ((pdev == pdev_array[0]) || (pdev == pdev_array[1]) || (pdev == pdev_array[2]) || (pdev == pdev_array[3]))) {
+		if ((table_cnt > 0) && ((pdev == pdev_array[0]) || (pdev == pdev_array[1]) || (pdev == pdev_array[2]) || (pdev == pdev_array[3]))) {
 			continue;
 		}
 
-		if(wch_pci_board_id[table_cnt].driver_data == WCH_BOARD_CH365_32S) {
+		if (wch_pci_board_id[table_cnt].driver_data == WCH_BOARD_CH365_32S) {
 			ch365_32s = 0x01;
 		}
 
 		pci_read_config_word(pdev, 0x2e, &sub_device_id);
 
-		if(ch365_32s) {
+		if (ch365_32s) {
 
 		} else {
-			if(sub_device_id == 0) {
+			if (sub_device_id == 0) {
 				printk("WCH Error: WCH Board (bus:%d device:%d), in configuration space,\n", pdev->bus->number, PCI_SLOT(pdev->devfn));
 				printk("           subdevice id isn't vaild.\n\n");
 				status = -EIO;
 				return status;
 			}
 
-			if(sub_device_id != wch_pci_board_id[table_cnt].subdevice) {
+			if (sub_device_id != wch_pci_board_id[table_cnt].subdevice) {
 				continue;
 			}
 		}
-		if(pdev == NULL) {
+		if (pdev == NULL) {
 			printk("WCH Error: PCI device object is an NULL pointer !\n\n");
 			status = -EIO;
 			return status;
@@ -271,7 +267,7 @@ wch_pci_board_probe(
 #endif
 			status = pci_enable_device(pdev);
 
-			if(status != 0) {
+			if (status != 0) {
 				printk("WCH Error: WCH Board Enable Fail !\n\n");
 				status = -ENXIO;
 				return status;
@@ -279,7 +275,7 @@ wch_pci_board_probe(
 		}
 
 		board_cnt++;
-		if(board_cnt > WCH_BOARDS_MAX) {
+		if (board_cnt > WCH_BOARDS_MAX) {
 			printk("\n");
 			printk("WCH Error: WCH Driver Module Support Four Boards In Maximum !\n\n");
 			status = -ENOSPC;
@@ -301,16 +297,16 @@ wch_pci_board_probe(
 		sb->board_number = board_cnt - 1;
 	}
 
-	if(board_cnt == 0) {
+	if (board_cnt == 0) {
 		printk("WCH Info : No WCH Multi-I/O Board Found !\n\n");
 		status = -ENXIO;
 		return status;
 	} else {
-		for(i = 0; i < WCH_BOARDS_MAX; i++) {
+		for (i = 0; i < WCH_BOARDS_MAX; i++) {
 			sb = &wch_board_table[i];
-			if(sb->board_enum > 0) {
+			if (sb->board_enum > 0) {
 				printk("\n");
-				if((sb->pb_info.num_serport) > 0) {
+				if ((sb->pb_info.num_serport) > 0) {
 					printk("WCH Info : Found WCH %s Series Board (%dS),\n", sb->pb_info.board_name, sb->pb_info.num_serport);
 				}
 
@@ -322,8 +318,7 @@ wch_pci_board_probe(
 	return status;
 }
 
-static
-int
+static int
 wch_get_pci_board_conf(
     void
 )
@@ -338,30 +333,30 @@ wch_get_pci_board_conf(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if(sb->board_enum > 0) {
+		if (sb->board_enum > 0) {
 			pdev = sb->pdev;
 			sb->ser_ports = sb->pb_info.num_serport;
 
 			wch_ser_port_total_cnt = wch_ser_port_total_cnt + sb->ser_ports;
 
 
-			if(wch_ser_port_total_cnt > WCH_SER_TOTAL_MAX) {
+			if (wch_ser_port_total_cnt > WCH_SER_TOTAL_MAX) {
 				printk("WCH Error: Too much serial port, maximum %d ports can be supported !\n\n", WCH_SER_TOTAL_MAX);
 				status = -EIO;
 				return status;
 			}
 
 
-			for(j = 0; j < WCH_PCICFG_BAR_TOTAL; j++) {
+			for (j = 0; j < WCH_PCICFG_BAR_TOTAL; j++) {
 				sb->bar_addr[j] = pci_resource_start(pdev, j);
 			}
 
-			if((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS) {
+			if ((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS) {
 				sb->board_membase = ioremap(sb->bar_addr[1], 4096);
-				if(!sb->board_membase) {
+				if (!sb->board_membase) {
 					status = -EIO;
 					printk("WCH Error: ioremap failed !\n");
 					return status;
@@ -369,7 +364,7 @@ wch_get_pci_board_conf(
 			}
 
 			sb->irq = sb->pdev->irq;
-			if(sb->irq <= 0) {
+			if (sb->irq <= 0) {
 				printk("WCH Error: WCH Board %s Series (bus:%d device:%d), in configuartion space, irq isn't valid !\n\n",
 				       sb->pb_info.board_name,
 				       sb->bus_number,
@@ -385,8 +380,7 @@ wch_get_pci_board_conf(
 	return status;
 }
 
-static
-int
+static int
 wch_assign_resource(
     void
 )
@@ -405,11 +399,11 @@ wch_assign_resource(
 
 	memset(wch_ser_table, 0, (WCH_SER_TOTAL_MAX + 1) * sizeof(struct wch_ser_port));
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if(sb->board_enum > 0) {
-			if(sb->ser_ports > 0) {
+		if (sb->board_enum > 0) {
+			if (sb->ser_ports > 0) {
 				sb->vector_mask = 0;
 
 				// assign serial port resource
@@ -417,65 +411,65 @@ wch_assign_resource(
 
 				sp = &wch_ser_table[ser_n];
 
-				if(sp == NULL) {
+				if (sp == NULL) {
 					status = -ENXIO;
 					printk("WCH Error: Serial port table address error !\n");
 					return status;
 				}
 
-				for(j = 0; j < sb->ser_ports; j++, ser_n++, sp++) {
+				for (j = 0; j < sb->ser_ports; j++, ser_n++, sp++) {
 					sp->port.chip_flag = sb->pb_info.port[j].chip_flag;
 					sp->port.iobase = sb->bar_addr[sb->pb_info.port[j].bar1] + sb->pb_info.port[j].offset1;
-					if((sb->board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP) {
+					if ((sb->board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP) {
 						sp->port.vector = 0;
-					} else if((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) {
+					} else if ((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) {
 						sp->port.chip_iobase = sb->bar_addr[sb->pb_info.port[j].bar1];
 						sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset;
-					} else if((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS) {
+					} else if ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS) {
 						sp->port.chip_iobase = sb->bar_addr[sb->pb_info.port[j].bar1];
-						if(j >= 0 && j < 0x04) {
+						if (j >= 0 && j < 0x04) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset;
-						} else if(j >= 0x04 && j < 0x0C) {
+						} else if (j >= 0x04 && j < 0x0C) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset_1;
-						} else if(j >= 0x0C && j < 0x14) {
+						} else if (j >= 0x0C && j < 0x14) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset_2;
-						} else if(j >= 0x14 && j < 0x1C) {
+						} else if (j >= 0x14 && j < 0x1C) {
 							sp->port.vector = sb->bar_addr[sb->pb_info.intr_vector_bar] + sb->pb_info.intr_vector_offset_3;
 						} else {
 
 						}
-					} else if((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS) {
+					} else if ((sb->board_flag & BOARDFLAG_CH365_32_PORTS) == BOARDFLAG_CH365_32_PORTS) {
 						sp->port.chip_iobase = sb->bar_addr[sb->pb_info.port[j].bar1];
 						sp->port.board_membase = sb->board_membase;
-						if(j >= 0 && j < 0x08) {
-							if(j >= 0 && j < 0x04) {
+						if (j >= 0 && j < 0x08) {
+							if (j >= 0 && j < 0x04) {
 								sp->port.port_membase = sb->board_membase + 0x100 + j * 0x10;
 							}
-							if(j >= 4 && j < 0x08) {
+							if (j >= 4 && j < 0x08) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x08 + (j - 4) * 0x10;
 							}
 						}
-						if(j >= 0x08 && j < 0x10) {
-							if(j >= 0x08 && j < 0x0C) {
+						if (j >= 0x08 && j < 0x10) {
+							if (j >= 0x08 && j < 0x0C) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x80 + (j - 0x08) * 0x10;
 							}
-							if(j >= 0x0C && j < 0x10) {
+							if (j >= 0x0C && j < 0x10) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x80 + 0x08 + (j - 0x0C) * 0x10;
 							}
 						}
-						if(j >= 0x10 && j < 0x18) {
-							if(j >= 0x10 && j < 0x14) {
+						if (j >= 0x10 && j < 0x18) {
+							if (j >= 0x10 && j < 0x14) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x100 + (j - 0x10) * 0x10;
 							}
-							if(j >= 0x14 && j < 0x18) {
+							if (j >= 0x14 && j < 0x18) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x100 + 0x08 + (j - 0x14) * 0x10;
 							}
 						}
-						if(j >= 0x18 && j < 0x20) {
-							if(j >= 0x18 && j < 0x1C) {
+						if (j >= 0x18 && j < 0x20) {
+							if (j >= 0x18 && j < 0x1C) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x180 + (j - 0x18) * 0x10;
 							}
-							if(j >= 0x1C && j < 0x20) {
+							if (j >= 0x1C && j < 0x20) {
 								sp->port.port_membase = sb->board_membase + 0x100 + 0x180 + 0x08 + (j - 0x1C) * 0x10;
 							}
 						}
@@ -492,8 +486,7 @@ wch_assign_resource(
 	return status;
 }
 
-static
-int
+static int
 wch_ser_port_table_init(
     void
 )
@@ -509,26 +502,26 @@ wch_ser_port_table_init(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if(sb == NULL) {
+		if (sb == NULL) {
 			status = -ENXIO;
 			printk("WCH Error: Board table pointer error !\n");
 			return status;
 		}
 
-		if((sb->board_enum > 0) && (sb->ser_ports > 0)) {
+		if ((sb->board_enum > 0) && (sb->ser_ports > 0)) {
 			n = sb->ser_port_index;
 			sp = &wch_ser_table[n];
 
-			if(sp == NULL) {
+			if (sp == NULL) {
 				status = -ENXIO;
 				printk("WCH Error: Serial port table pointer error !\n");
 				return status;
 			}
 
-			for(j = 0; j < sb->ser_ports; j++, n++, sp++) {
+			for (j = 0; j < sb->ser_ports; j++, n++, sp++) {
 				sp->port.board_enum = sb->board_enum;
 				sp->port.bus_number = sb->bus_number;
 				sp->port.dev_number = sb->dev_number;
@@ -538,7 +531,7 @@ wch_ser_port_table_init(
 				sp->port.irq = sb->irq;
 				sp->port.line = n;
 				sp->port.uartclk = CRYSTAL_FREQ / 12;
-				if(ch365_32s) {
+				if (ch365_32s) {
 					sp->port.iotype = WCH_UPIO_MEM;
 				} else {
 					sp->port.iotype = WCH_UPIO_PORT;
@@ -550,60 +543,60 @@ wch_ser_port_table_init(
 				spin_lock_init(&sp->port.lock);
 
 
-				if(sp->port.chip_flag == WCH_BOARD_CH351_2S) {
+				if (sp->port.chip_flag == WCH_BOARD_CH351_2S) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH351_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH351_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH352_2S || sp->port.chip_flag == WCH_BOARD_CH352_1S1P) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH352_2S || sp->port.chip_flag == WCH_BOARD_CH352_1S1P) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH352_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH352_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH353_4S || sp->port.chip_flag == WCH_BOARD_CH353_2S1P || sp->port.chip_flag == WCH_BOARD_CH353_2S1PAR) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH353_4S || sp->port.chip_flag == WCH_BOARD_CH353_2S1P || sp->port.chip_flag == WCH_BOARD_CH353_2S1PAR) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH353_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH353_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH355_4S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH355_4S) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH355_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH355_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH356_4S1P || sp->port.chip_flag == WCH_BOARD_CH356_6S || sp->port.chip_flag == WCH_BOARD_CH356_8S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH356_4S1P || sp->port.chip_flag == WCH_BOARD_CH356_6S || sp->port.chip_flag == WCH_BOARD_CH356_8S) {
 					sp->port.type = PORT_SER_16550A;
 					sp->port.fifosize = CH356_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH356_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH357_4S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH357_4S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH357_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH357_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH358_4S1P || sp->port.chip_flag == WCH_BOARD_CH358_8S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH358_4S1P || sp->port.chip_flag == WCH_BOARD_CH358_8S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH358_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH358_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH359_16S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH359_16S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH359_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH359_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH382_2S || sp->port.chip_flag == WCH_BOARD_CH382_2S1P) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH382_2S || sp->port.chip_flag == WCH_BOARD_CH382_2S1P) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH382_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH382_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH384_4S || sp->port.chip_flag == WCH_BOARD_CH384_4S1P) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH384_4S || sp->port.chip_flag == WCH_BOARD_CH384_4S1P) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH384_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH384_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH384_8S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH384_8S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH358_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH358_TRIGGER_LEVEL_SET;
-				} else if(sp->port.chip_flag == WCH_BOARD_CH384_28S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH384_28S) {
 					sp->port.type = PORT_SER_16750;
-					if(j >= 0 && j < 0x04) {
+					if (j >= 0 && j < 0x04) {
 						sp->port.fifosize = CH384_FIFOSIZE_SET;
 						sp->port.rx_trigger = CH384_TRIGGER_LEVEL_SET;
 					} else {
 						sp->port.fifosize = CH358_FIFOSIZE_SET;
 						sp->port.rx_trigger = CH358_TRIGGER_LEVEL_SET;
 					}
-				} else if(sp->port.chip_flag == WCH_BOARD_CH365_32S) {
+				} else if (sp->port.chip_flag == WCH_BOARD_CH365_32S) {
 					sp->port.type = PORT_SER_16750;
 					sp->port.fifosize = CH438_FIFOSIZE_SET;
 					sp->port.rx_trigger = CH438_TRIGGER_LEVEL_SET;
@@ -614,7 +607,7 @@ wch_ser_port_table_init(
 				}
 
 
-				if((sb->pb_info.board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP) {
+				if ((sb->pb_info.board_flag & BOARDFLAG_REMAP) == BOARDFLAG_REMAP) {
 					sp->port.vector_mask = 0;
 					sp->port.port_flag = PORTFLAG_REMAP;
 				} else {
@@ -635,8 +628,7 @@ wch_ser_port_table_init(
 }
 
 #if WCH_DBG
-void
-wch_debug(
+void wch_debug(
     void
 ) // \B5\F7\CA\D4
 {
@@ -653,9 +645,9 @@ wch_debug(
 #if WCH_DBG_BOARD
 	printk("\n");
 	printk("======== board info ========\n");
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
-		if(sb->board_enum != -1) {
+		if (sb->board_enum != -1) {
 			printk(" name         : %s\n", sb->pb_info.board_name);
 			printk(" board_enum   : %d\n", sb->board_enum);
 			printk(" board_number : %d\n", sb->board_number);
@@ -678,9 +670,9 @@ wch_debug(
 #if WCH_DBG_SERPORT
 	printk("\n");
 	printk("======== serial info ========\n");
-	for(j = 0; j < wch_ser_port_total_cnt; j++) {
+	for (j = 0; j < wch_ser_port_total_cnt; j++) {
 		sp = &wch_ser_table[j];
-		if(sp->port.iobase) {
+		if (sp->port.iobase) {
 			printk(" number       : %d\n", j);
 			printk(" name         : %s\n", sp->port.pb_info.board_name);
 			printk(" iobase       : 0x%x\n", sp->port.iobase);
@@ -700,10 +692,8 @@ wch_debug(
 }
 #endif
 
-
 #if WCH_DBG_SERIAL
-void
-ch365_32s_test(
+void ch365_32s_test(
     void
 )
 {
@@ -711,9 +701,9 @@ ch365_32s_test(
 	int i;
 	dbg_serial("\n");
 	dbg_serial("======== board info ========\n");
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
-		if(sb->board_enum != -1) {
+		if (sb->board_enum != -1) {
 			dbg_serial(" ch438_1_uart0 LSR = %x\n", readb(sb->board_membase + 0x100 + 0x05));
 			dbg_serial(" ch438_1_uart1 LSR = %x\n", readb(sb->board_membase + 0x100 + 0x05 + 0x08));
 			dbg_serial(" ch438_1_uart2 LSR = %x\n", readb(sb->board_membase + 0x100 + 0x05 + 0x10));
@@ -757,8 +747,7 @@ ch365_32s_test(
 }
 #endif
 
-int
-wch_register_irq(
+int wch_register_irq(
     void
 )
 {
@@ -771,38 +760,38 @@ wch_register_irq(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if(sb == NULL) {
+		if (sb == NULL) {
 			status = -ENXIO;
 			printk("WCH Error: Board table pointer error !\n");
 			return status;
 		}
 
-		if(sb->board_enum > 0) {
+		if (sb->board_enum > 0) {
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,18))
 			status = request_irq(sb->irq, wch_interrupt, IRQF_SHARED, "wch", sb);
 #else
 			status = request_irq(sb->irq, wch_interrupt, SA_SHIRQ, "wch", sb);
 #endif
 
-			if(status) {
+			if (status) {
 				printk("WCH Error: WCH Multi-I/O %s Board(bus:%d device:%d), request\n", sb->pb_info.board_name, sb->bus_number, sb->dev_number);
 				printk("           IRQ %d fail, IRQ %d may be conflit with another device.\n", sb->irq, sb->irq);
 				return status;
 			}
 
 		}
-		if(ch365_32s) {
+		if (ch365_32s) {
 			outb(inb(sb->bar_addr[0] + 0xF8) & 0xFE, sb->bar_addr[0] + 0xF8);
 			outb(((inb(sb->bar_addr[0] + 0xFA) & 0xFB) | 0x03), sb->bar_addr[0] + 0xFA); // set read/write plus width 240ns->120ns
 		}
 
-		if(((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
-		   ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
+		if (((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
+		    ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
 			chip_iobase = sb->bar_addr[0];
-			if(chip_iobase) {
+			if (chip_iobase) {
 				outb(inb(chip_iobase + 0xEB) | 0x02, chip_iobase + 0xEB);
 				/* set read/write plus width 120ns->210ns */
 				outb(inb(chip_iobase + 0xFA) | 0x10, chip_iobase + 0xFA);
@@ -813,10 +802,9 @@ wch_register_irq(
 	return status;
 }
 
-void
-wch_iounmap(
+void wch_iounmap(
     void
-) // \CAͷ\C5IO
+)
 {
 	struct wch_board *sb = NULL;
 	int i;
@@ -825,18 +813,16 @@ wch_iounmap(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if(sb->board_enum > 0) {
+		if (sb->board_enum > 0) {
 			iounmap(sb->board_membase);
 		}
 	}
 }
 
-
-void
-wch_release_irq(
+void wch_release_irq(
     void
 )
 {
@@ -848,19 +834,19 @@ wch_release_irq(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for(i = 0; i < WCH_BOARDS_MAX; i++) {
+	for (i = 0; i < WCH_BOARDS_MAX; i++) {
 		sb = &wch_board_table[i];
 
-		if(sb->board_enum > 0) {
+		if (sb->board_enum > 0) {
 			free_irq(sb->irq, sb);
 		}
-		if(ch365_32s) {
+		if (ch365_32s) {
 			outb(inb(sb->bar_addr[0] + 0xF8) | 0x01, sb->bar_addr[0] + 0xF8);
 		}
-		if(((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
-		   ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
+		if (((sb->board_flag & BOARDFLAG_CH384_8_PORTS) == BOARDFLAG_CH384_8_PORTS) ||
+		    ((sb->board_flag & BOARDFLAG_CH384_28_PORTS) == BOARDFLAG_CH384_28_PORTS)) {
 			chip_iobase = sb->bar_addr[0];
-			if(chip_iobase)
+			if (chip_iobase)
 				outb(inb(chip_iobase + 0xEB) & 0xFD, chip_iobase + 0xEB);
 		}
 	}
@@ -872,9 +858,7 @@ static struct ser_driver wch_ser_reg = {
 	.minor = 0,
 };
 
-static
-int
-__init
+static int __init
 wch_init(
     void
 )
@@ -891,42 +875,42 @@ wch_init(
 	wch_ser_port_total_cnt = 0;
 
 	status = wch_pci_board_probe();
-	if(status != 0) {
+	if (status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci board probe success\n");
 	status = wch_get_pci_board_conf();
-	if(status != 0) {
+	if (status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci board conf success\n");
 
 	status = wch_assign_resource();
-	if(status != 0) {
+	if (status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci assign success\n");
 
 	status = wch_ser_port_table_init();
-	if(status != 0) {
+	if (status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->ser port table init success\n");
 
 	status = wch_register_irq();
-	if(status != 0) {
+	if (status != 0) {
 		goto step1_fail;
 	}
 	printk("------------------->pci register irq success\n");
 
 	status = wch_ser_register_driver(&wch_ser_reg);
-	if(status != 0) {
+	if (status != 0) {
 		goto step2_fail;
 	}
 	printk("------------------->ser register driver success\n");
 
 	status = wch_ser_register_ports(&wch_ser_reg);
-	if(status != 0) {
+	if (status != 0) {
 		goto step3_fail;
 	}
 
@@ -960,9 +944,7 @@ step1_fail:
 
 }
 
-static
-void
-__exit
+static void __exit
 wch_exit(
     void
 )

--- a/driver/wch_serial.c
+++ b/driver/wch_serial.c
@@ -10,23 +10,23 @@ static DECLARE_MUTEX(ser_port_sem);
 #define wch_ser_users(state) ((state)->count + ((state)->info ? (state)->info->blocked_open : 0))
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-struct serial_uart_config{
-    char *name;
-    int dfl_xmit_fifo_size;
-    int flags;
+struct serial_uart_config {
+	char *name;
+	int dfl_xmit_fifo_size;
+	int flags;
 };
 #endif
 
 static const struct serial_uart_config wch_uart_config[PORT_SER_MAX_UART + 1] = {
-    {"unknown", 1, 0},
-    {"8250", 1, 0},
-    {"16450", 1, 0},
-    {"16550", 1, 0},
-    {"16550A", 16, UART_CLEAR_FIFO | UART_USE_FIFO},
-    {"Cirrus", 1, 0},
-    {"ST16650", 1, 0},
-    {"ST16650V2", 32, UART_CLEAR_FIFO | UART_USE_FIFO},
-    {"TI16750", 64, UART_CLEAR_FIFO | UART_USE_FIFO},
+	{"unknown", 1, 0},
+	{"8250", 1, 0},
+	{"16450", 1, 0},
+	{"16550", 1, 0},
+	{"16550A", 16, UART_CLEAR_FIFO | UART_USE_FIFO},
+	{"Cirrus", 1, 0},
+	{"ST16650", 1, 0},
+	{"ST16650V2", 32, UART_CLEAR_FIFO | UART_USE_FIFO},
+	{"TI16750", 64, UART_CLEAR_FIFO | UART_USE_FIFO},
 };
 
 
@@ -160,33 +160,31 @@ static void WRITE_UART_DLM(struct wch_ser_port *, int);
 static
 unsigned char
 READ_INTERRUPT_VECTOR_BYTE(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
-    unsigned char data = 0;
+	unsigned char data = 0;
 
-    if (sp->port.vector)
-    {
-        data = inb(sp->port.vector);
+	if(sp->port.vector) {
+		data = inb(sp->port.vector);
 
-        return data;
-    }
+		return data;
+	}
 
-    return 0;
+	return 0;
 }
 
 static
 unsigned int
 READ_INTERRUPT_VECTOR_WORD(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
 	unsigned int data = 0;
 	unsigned int vet1 = 0;
 	unsigned int vet2 = 0;
 
-    if (sp->port.vector)
-    {
+	if(sp->port.vector) {
 		vet1 = inb(sp->port.vector);
 		vet2 = inb(sp->port.vector - 0x10);
 
@@ -194,348 +192,292 @@ READ_INTERRUPT_VECTOR_WORD(
 		data = (vet1 | vet2);
 
 		return data;
-    }
+	}
 
-    return 0;
+	return 0;
 }
 
 static
 unsigned long
 READ_INTERRUPT_VECTOR_DWORD(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
 	unsigned long data = 0;
 
-	if (sp->port.iobase)
-	{
+	if(sp->port.iobase) {
 		data = inl(sp->port.chip_iobase + 0xE8);
-    }
+	}
 
-    return data;
+	return data;
 }
 
 static
 unsigned char
 READ_UART_RX(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
-    unsigned char data = 0;
+	unsigned char data = 0;
 
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			data = readb(sp->port.port_membase + UART_RX);
-		}
-		else
-		{
+		} else {
 			data = inb(sp->port.iobase + UART_RX);
 		}
 
-       	return data;
-    }
+		return data;
+	}
 
-    return 0;
+	return 0;
 }
 
 static
 void
 WRITE_UART_TX(
-	struct wch_ser_port *sp,
-	unsigned char data
-	)
+    struct wch_ser_port *sp,
+    unsigned char data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_TX);
-		}
-		else
-		{
+		} else {
 			outb(data, sp->port.iobase + UART_TX);
 		}
-    }
+	}
 }
 
 static
 void
 WRITE_UART_IER(
-	struct wch_ser_port *sp,
-	unsigned char data
-	)
+    struct wch_ser_port *sp,
+    unsigned char data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_IER);
-		}
-		else
-		{
+		} else {
 			outb(data, sp->port.iobase + UART_IER);
 		}
-    }
+	}
 }
 
 static
 unsigned char
 READ_UART_IIR(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
-    unsigned char data = 0;
+	unsigned char data = 0;
 
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			data = readb(sp->port.port_membase + UART_IIR);
-		}
-		else
-		{
+		} else {
 			data = inb(sp->port.iobase + UART_IIR);
 		}
 
 		return data;
-    }
+	}
 
-    return 0;
+	return 0;
 }
 
 static
 void
 WRITE_UART_FCR(
-	struct wch_ser_port *sp,
-	unsigned char data
-	)
+    struct wch_ser_port *sp,
+    unsigned char data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_FCR);
-		}
-		else
-		{
+		} else {
 			outb(data, sp->port.iobase + UART_FCR);
 		}
-    }
+	}
 }
 
 static
 unsigned char
 READ_UART_LCR(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
-    unsigned char data = 0;
+	unsigned char data = 0;
 
-   	if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			data = readb(sp->port.port_membase + UART_LCR);
-		}
-		else
-		{
+		} else {
 			data = inb(sp->port.iobase + UART_LCR);
 		}
 
-        return data;
-    }
+		return data;
+	}
 
-    return 0;
+	return 0;
 }
 
 static
 void
 WRITE_UART_LCR(
-	struct wch_ser_port *sp,
-	unsigned char data
-	)
+    struct wch_ser_port *sp,
+    unsigned char data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_LCR);
-		}
-		else
-		{
+		} else {
 			outb(data, sp->port.iobase + UART_LCR);
 		}
-    }
+	}
 }
 
 static
 void
 WRITE_UART_MCR(
-	struct wch_ser_port *sp,
-	unsigned char data
-	)
+    struct wch_ser_port *sp,
+    unsigned char data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_MCR);
-		}
-		else
-        {
+		} else {
 			outb(data, sp->port.iobase + UART_MCR);
 		}
-    }
+	}
 }
 
 static
 unsigned char
 READ_UART_LSR(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
-    unsigned char data = 0;
+	unsigned char data = 0;
 
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			data = readb(sp->port.port_membase + UART_LSR);
-		}
-		else
-		{
+		} else {
 			data = inb(sp->port.iobase + UART_LSR);
 		}
 
-     	return data;
-    }
+		return data;
+	}
 
-    return 0;
+	return 0;
 }
 
 
 static
 unsigned char
 READ_UART_MSR(
-	struct wch_ser_port *sp
-	)
+    struct wch_ser_port *sp
+)
 {
-    unsigned char data = 0;
+	unsigned char data = 0;
 
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			data = readb(sp->port.port_membase + UART_MSR);
-		}
-		else
-        {
+		} else {
 			data = inb(sp->port.iobase + UART_MSR);
 		}
 
-        return data;
-    }
+		return data;
+	}
 
-    return 0;
+	return 0;
 }
 
 
 static
 void
 WRITE_UART_DLL(
-	struct wch_ser_port *sp,
-	int data
-	)
+    struct wch_ser_port *sp,
+    int data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_DLL);
-		}
-		else
-		{
+		} else {
 			outb(data, sp->port.iobase + UART_DLL);
 		}
-    }
+	}
 }
 
 static
 void
 WRITE_UART_DLM(
-	struct wch_ser_port *sp,
-	int data
-	)
+    struct wch_ser_port *sp,
+    int data
+)
 {
-    if (sp->port.iobase)
-    {
-		if (ch365_32s)
-		{
+	if(sp->port.iobase) {
+		if(ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_DLM);
-		}
-		else
-		{
+		} else {
 			outb(data, sp->port.iobase + UART_DLM);
 		}
-    }
+	}
 }
 
 static _INLINE_ void
 ser_handle_cts_change(
-					  struct ser_port *port,
-					  unsigned int status
-					  )
+    struct ser_port *port,
+    unsigned int status
+)
 {
-    struct ser_info *info = port->info;
-    struct tty_struct *tty = info->tty;
+	struct ser_info *info = port->info;
+	struct tty_struct *tty = info->tty;
 
 	port->icount.cts++;
 
-    if (info->flags & WCH_UIF_CTS_FLOW)
-	{
-        if (tty->hw_stopped)
-        {
-			if (status)
-            {
-                tty->hw_stopped = 0;
-                wch_ser_start_tx(port, 0);
-                ser_write_wakeup(port);
-            }
-        }
-        else
-        {
-           	if (!status)
-           	{
-               	tty->hw_stopped = 1;
-               	wch_ser_stop_tx(port, 0);
-           	}
-        }
-    }
+	if(info->flags & WCH_UIF_CTS_FLOW) {
+		if(tty->hw_stopped) {
+			if(status) {
+				tty->hw_stopped = 0;
+				wch_ser_start_tx(port, 0);
+				ser_write_wakeup(port);
+			}
+		} else {
+			if(!status) {
+				tty->hw_stopped = 1;
+				wch_ser_stop_tx(port, 0);
+			}
+		}
+	}
 }
 
 
 static _INLINE_ void
 ser_update_mctrl(
-				 struct ser_port *port,
-				 unsigned int set,
-				 unsigned int clear
-				 )
+    struct ser_port *port,
+    unsigned int set,
+    unsigned int clear
+)
 {
-    unsigned long flags;
-    unsigned int old;
+	unsigned long flags;
+	unsigned int old;
 
 	spin_lock_irqsave(&port->lock, flags);
 
-    old = port->mctrl;
-    port->mctrl = (old & ~clear) | set;
+	old = port->mctrl;
+	port->mctrl = (old & ~clear) | set;
 
-    if (old != port->mctrl)
-    {
-        wch_ser_set_mctrl(port, port->mctrl);
-    }
-    spin_unlock_irqrestore(&port->lock, flags);
+	if(old != port->mctrl) {
+		wch_ser_set_mctrl(port, port->mctrl);
+	}
+	spin_unlock_irqrestore(&port->lock, flags);
 }
 
 
@@ -545,294 +487,273 @@ ser_update_mctrl(
 
 static void
 ser_write_wakeup(
-				 struct ser_port *port
-				 )
+    struct ser_port *port
+)
 {
-    struct ser_info *info = port->info;
-    tasklet_schedule(&info->tlet);
+	struct ser_info *info = port->info;
+	tasklet_schedule(&info->tlet);
 }
 
 
 static void
 ser_stop(
-		 struct tty_struct *tty
-		 )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    unsigned long flags;
-    int line = WCH_SER_DEVNUM(tty);
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	unsigned long flags;
+	int line = WCH_SER_DEVNUM(tty);
 
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    spin_lock_irqsave(&port->lock, flags);
-    wch_ser_stop_tx(port, 1);
-    spin_unlock_irqrestore(&port->lock, flags);
+	spin_lock_irqsave(&port->lock, flags);
+	wch_ser_stop_tx(port, 1);
+	spin_unlock_irqrestore(&port->lock, flags);
 }
 
 
 static void
 _ser_start(
-		   struct tty_struct *tty
-		   )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = tty->driver_data;
-    struct ser_port *port = state->port;
-    if (!ser_circ_empty(&state->info->xmit) && state->info->xmit.buf && !tty->stopped && !tty->hw_stopped)
-    {
-        wch_ser_start_tx(port, 1);
-    }
+	struct ser_state *state = tty->driver_data;
+	struct ser_port *port = state->port;
+	if(!ser_circ_empty(&state->info->xmit) && state->info->xmit.buf && !tty->stopped && !tty->hw_stopped) {
+		wch_ser_start_tx(port, 1);
+	}
 }
 
 
 static void
 ser_start(
-		  struct tty_struct *tty
-		  )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
 	unsigned long flags;
 
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
 	spin_lock_irqsave(&port->lock, flags);
-    _ser_start(tty);
+	_ser_start(tty);
 	spin_unlock_irqrestore(&port->lock, flags);
 }
 
 
 static void
 ser_tasklet_action(
-				   unsigned long data
-				   )
+    unsigned long data
+)
 {
-    struct ser_state *state = (struct ser_state *)data;
-    struct tty_struct *tty = NULL;
-    tty = state->info->tty;
-    if (tty)
-    {
+	struct ser_state *state = (struct ser_state *)data;
+	struct tty_struct *tty = NULL;
+	tty = state->info->tty;
+	if(tty) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31))
-        if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup)
-        {
+		if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup) {
 			tty->ldisc->ops->write_wakeup(tty);
 		}
 
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27) && LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,30))
 		{
-			if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup)
-			{
+			if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup) {
 				tty->ldisc.ops->write_wakeup(tty);
 			}
 		}
 #else
-        if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup)
-        {
+		if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup) {
 			tty->ldisc.write_wakeup(tty);
 		}
 #endif
-        wake_up_interruptible(&tty->write_wait);
-    }
+		wake_up_interruptible(&tty->write_wait);
+	}
 }
 
 
 static int
 ser_startup(
-			struct ser_state *state,
-			int init_hw
-			)
+    struct ser_state *state,
+    int init_hw
+)
 {
-    struct ser_info *info = state->info;
-    struct ser_port *port = state->port;
-    unsigned long page;
-    int retval = 0;
+	struct ser_info *info = state->info;
+	struct ser_port *port = state->port;
+	unsigned long page;
+	int retval = 0;
 
-    if (info->flags & WCH_UIF_INITIALIZED)
-    {
-        return 0;
-    }
-
-
-    if (info->tty)
-    {
-        set_bit(TTY_IO_ERROR, &info->tty->flags);
-    }
+	if(info->flags & WCH_UIF_INITIALIZED) {
+		return 0;
+	}
 
 
-    if (port->type == PORT_UNKNOWN)
-    {
-        return 0;
-    }
+	if(info->tty) {
+		set_bit(TTY_IO_ERROR, &info->tty->flags);
+	}
 
 
-    if (!info->xmit.buf)
-    {
-        page = get_zeroed_page(GFP_KERNEL);
-        if (!page)
-        {
-            return -ENOMEM;
-        }
+	if(port->type == PORT_UNKNOWN) {
+		return 0;
+	}
 
-        info->xmit.buf = (unsigned char *) page;
-        info->tmpbuf = info->xmit.buf + WCH_UART_XMIT_SIZE;
+
+	if(!info->xmit.buf) {
+		page = get_zeroed_page(GFP_KERNEL);
+		if(!page) {
+			return -ENOMEM;
+		}
+
+		info->xmit.buf = (unsigned char *) page;
+		info->tmpbuf = info->xmit.buf + WCH_UART_XMIT_SIZE;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
-		sema_init(&info->tmpbuf_sem,1);
+		sema_init(&info->tmpbuf_sem, 1);
 #else
 		init_MUTEX(&info->tmpbuf_sem);
 #endif
-        ser_circ_clear(&info->xmit);
-    }
+		ser_circ_clear(&info->xmit);
+	}
 
-    retval = wch_ser_startup(port);
+	retval = wch_ser_startup(port);
 
-    if (retval == 0)
-    {
-        if (init_hw)
-        {
-            ser_change_speed(state, NULL);
+	if(retval == 0) {
+		if(init_hw) {
+			ser_change_speed(state, NULL);
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-            if (info->tty->termios->c_cflag & CBAUD)
+			if(info->tty->termios->c_cflag & CBAUD)
 #else
-	    if (info->tty->termios.c_cflag & CBAUD)
+			if(info->tty->termios.c_cflag & CBAUD)
 #endif
-            {
-            	printk("%s set rtsdtr\n", __func__);
+			{
+				printk("%s set rtsdtr\n", __func__);
 				set_mctrl(port, TIOCM_RTS | TIOCM_DTR);
-            }
-        }
+			}
+		}
 
-        info->flags |= WCH_UIF_INITIALIZED;
+		info->flags |= WCH_UIF_INITIALIZED;
 
-        clear_bit(TTY_IO_ERROR, &info->tty->flags);
-    }
+		clear_bit(TTY_IO_ERROR, &info->tty->flags);
+	}
 
 
-    if (retval && capable(CAP_SYS_ADMIN))
-    {
-        retval = 0;
-    }
+	if(retval && capable(CAP_SYS_ADMIN)) {
+		retval = 0;
+	}
 	set_mctrl(port, TIOCM_OUT2);
 
-    return retval;
+	return retval;
 }
 
 
 static void
 ser_shutdown(
-			 struct ser_state *state
-			 )
+    struct ser_state *state
+)
 {
-    struct ser_info *info = state->info;
-    struct ser_port *port = state->port;
+	struct ser_info *info = state->info;
+	struct ser_port *port = state->port;
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 
-    if (!(info->flags & WCH_UIF_INITIALIZED))
-    {
-        return;
-    }
+	if(!(info->flags & WCH_UIF_INITIALIZED)) {
+		return;
+	}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    if (!info->tty || (info->tty->termios->c_cflag & HUPCL))
+	if(!info->tty || (info->tty->termios->c_cflag & HUPCL))
 #else
-    if (!info->tty || (info->tty->termios.c_cflag & HUPCL))
+	if(!info->tty || (info->tty->termios.c_cflag & HUPCL))
 #endif
-    {
-        clear_mctrl(port, TIOCM_DTR | TIOCM_RTS);
-    }
+	{
+		clear_mctrl(port, TIOCM_DTR | TIOCM_RTS);
+	}
 
-    wake_up_interruptible(&info->delta_msr_wait);
+	wake_up_interruptible(&info->delta_msr_wait);
 
-    wch_ser_shutdown(port);
+	wch_ser_shutdown(port);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    synchronize_irq(port->irq);
+	synchronize_irq(port->irq);
 #endif
 
-    if (info->xmit.buf)
-    {
-        free_page((unsigned long)info->xmit.buf);
-        info->xmit.buf = NULL;
-        if(info->tmpbuf)
-	    	info->tmpbuf = NULL;
-    }
+	if(info->xmit.buf) {
+		free_page((unsigned long)info->xmit.buf);
+		info->xmit.buf = NULL;
+		if(info->tmpbuf)
+			info->tmpbuf = NULL;
+	}
 
-    tasklet_kill(&info->tlet);
+	tasklet_kill(&info->tlet);
 
-    if (info->tty)
-    {
-        set_bit(TTY_IO_ERROR, &info->tty->flags);
-    }
+	if(info->tty) {
+		set_bit(TTY_IO_ERROR, &info->tty->flags);
+	}
 
 	// modified on 20200929
 	sp->mcr = 0;
 	clear_mctrl(port, TIOCM_OUT2 | TIOCM_DTR | TIOCM_RTS);
 
-    info->flags &= ~WCH_UIF_INITIALIZED;
+	info->flags &= ~WCH_UIF_INITIALIZED;
 }
 
 
 static _INLINE_ void
 _ser_put_char(
-			  struct ser_port *port,
-			  struct circ_buf *circ,
-			  unsigned char c
-			  )
+    struct ser_port *port,
+    struct circ_buf *circ,
+    unsigned char c
+)
 {
-    unsigned long flags;
-    if (!circ->buf)
-    {
-        return;
-    }
+	unsigned long flags;
+	if(!circ->buf) {
+		return;
+	}
 
-    spin_lock_irqsave(&port->lock, flags);
+	spin_lock_irqsave(&port->lock, flags);
 
-    if (ser_circ_chars_free(circ) != 0)
-    {
-        circ->buf[circ->head] = c;
-        circ->head = (circ->head + 1) & (WCH_UART_XMIT_SIZE - 1);
-    }
-    spin_unlock_irqrestore(&port->lock, flags);
+	if(ser_circ_chars_free(circ) != 0) {
+		circ->buf[circ->head] = c;
+		circ->head = (circ->head + 1) & (WCH_UART_XMIT_SIZE - 1);
+	}
+	spin_unlock_irqrestore(&port->lock, flags);
 }
 
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
 static int
 ser_put_char(
-			 struct tty_struct *tty,
-			 unsigned char ch
-			 )
+    struct tty_struct *tty,
+    unsigned char ch
+)
 #else
 static void
 ser_put_char(
-			 struct tty_struct *tty,
-			 unsigned char ch
-			 )
+    struct tty_struct *tty,
+    unsigned char ch
+)
 #endif
 {
-    struct ser_state *state = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
+	struct ser_state *state = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
-        return 0;
+		return 0;
 #else
 		return;
 #endif
-    }
+	}
 
-    state = tty->driver_data;
+	state = tty->driver_data;
 	_ser_put_char(state->port, &state->info->xmit, ch);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
@@ -844,80 +765,73 @@ ser_put_char(
 
 static void
 ser_flush_chars(
-				struct tty_struct *tty
-				)
+    struct tty_struct *tty
+)
 {
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    ser_start(tty);
+	ser_start(tty);
 }
 
 
 static int
 ser_chars_in_buffer(
-					struct tty_struct *tty
-					)
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return 0;
-    }
+	struct ser_state *state = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return 0;
+	}
 
-    state = tty->driver_data;
-    return ser_circ_chars_pending(&state->info->xmit);
+	state = tty->driver_data;
+	return ser_circ_chars_pending(&state->info->xmit);
 }
 
 
 static void
 ser_flush_buffer(
-				 struct tty_struct *tty
-				 )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    unsigned long flags;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	unsigned long flags;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    if (!state || !state->info)
-    {
-        return;
-    }
+	if(!state || !state->info) {
+		return;
+	}
 
-    spin_lock_irqsave(&port->lock, flags);
-    ser_circ_clear(&state->info->xmit);
-    spin_unlock_irqrestore(&port->lock, flags);
+	spin_lock_irqsave(&port->lock, flags);
+	ser_circ_clear(&state->info->xmit);
+	spin_unlock_irqrestore(&port->lock, flags);
 
-    wake_up_interruptible(&tty->write_wait);
+	wake_up_interruptible(&tty->write_wait);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31))
-    if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup)
-    {
-        (tty->ldisc->ops->write_wakeup)(tty);
-    }
+	if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup) {
+		(tty->ldisc->ops->write_wakeup)(tty);
+	}
 
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27) && LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,30))
 
-    if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup)
-    {
-        (tty->ldisc.ops->write_wakeup)(tty);
-    }
+	if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup) {
+		(tty->ldisc.ops->write_wakeup)(tty);
+	}
 
 #else
-	if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup)
-    {
+	if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup) {
 		(tty->ldisc.write_wakeup)(tty);
 	}
 #endif
@@ -926,172 +840,159 @@ ser_flush_buffer(
 
 static void
 ser_send_xchar(
-			   struct tty_struct *tty,
-			   char ch
-			   )
+    struct tty_struct *tty,
+    char ch
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    unsigned long flags;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	unsigned long flags;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
-    port->x_char = ch;
+	state = tty->driver_data;
+	port = state->port;
+	port->x_char = ch;
 
-    if (ch)
-    {
-        spin_lock_irqsave(&port->lock, flags);
-        wch_ser_start_tx(port, 0);
-        spin_unlock_irqrestore(&port->lock, flags);
-    }
+	if(ch) {
+		spin_lock_irqsave(&port->lock, flags);
+		wch_ser_start_tx(port, 0);
+		spin_unlock_irqrestore(&port->lock, flags);
+	}
 }
 
 
 static void
 ser_throttle(
-			 struct tty_struct *tty
-			 )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    port->ldisc_stop_rx = 1;
+	port->ldisc_stop_rx = 1;
 
-    if (I_IXOFF(tty))
-    {
-        ser_send_xchar(tty, STOP_CHAR(tty));
-    }
+	if(I_IXOFF(tty)) {
+		ser_send_xchar(tty, STOP_CHAR(tty));
+	}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    if (tty->termios->c_cflag & CRTSCTS)
+	if(tty->termios->c_cflag & CRTSCTS)
 #else
-    if (tty->termios.c_cflag & CRTSCTS)
+	if(tty->termios.c_cflag & CRTSCTS)
 #endif
-    {
-        clear_mctrl(state->port, TIOCM_RTS);
-    }
+	{
+		clear_mctrl(state->port, TIOCM_RTS);
+	}
 }
 
 
 static void
 ser_unthrottle(
-			   struct tty_struct *tty
-			   )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    port->ldisc_stop_rx = 0;
+	port->ldisc_stop_rx = 0;
 
-    if (I_IXOFF(tty))
-    {
-        if (port->x_char)
-        {
-            port->x_char = 0;
-        }
-        else
-        {
-            ser_send_xchar(tty, START_CHAR(tty));
-        }
-    }
+	if(I_IXOFF(tty)) {
+		if(port->x_char) {
+			port->x_char = 0;
+		} else {
+			ser_send_xchar(tty, START_CHAR(tty));
+		}
+	}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    if (tty->termios->c_cflag & CRTSCTS)
+	if(tty->termios->c_cflag & CRTSCTS)
 #else
-    if (tty->termios.c_cflag & CRTSCTS)
+	if(tty->termios.c_cflag & CRTSCTS)
 #endif
-    {
-        set_mctrl(port, TIOCM_RTS);
-    }
+	{
+		set_mctrl(port, TIOCM_RTS);
+	}
 }
 
 
 static int
 ser_get_info(
-			 struct ser_state *state,
-			 struct serial_struct *retinfo
-			 )
+    struct ser_state *state,
+    struct serial_struct *retinfo
+)
 {
-    struct ser_port *port = state->port;
-    struct serial_struct tmp;
-    memset(&tmp, 0, sizeof(tmp));
-    tmp.type = port->type;
-    tmp.line = port->line;
-    tmp.port = port->iobase;
+	struct ser_port *port = state->port;
+	struct serial_struct tmp;
+	memset(&tmp, 0, sizeof(tmp));
+	tmp.type = port->type;
+	tmp.line = port->line;
+	tmp.port = port->iobase;
 
-    if (WCH_HIGH_BITS_OFFSET)
-    {
-        tmp.port_high = (long) port->iobase >> WCH_HIGH_BITS_OFFSET;
-    }
+	if(WCH_HIGH_BITS_OFFSET) {
+		tmp.port_high = (long) port->iobase >> WCH_HIGH_BITS_OFFSET;
+	}
 
-    tmp.irq = port->irq;
-    tmp.flags = port->flags;
-    tmp.xmit_fifo_size = port->fifosize;
-    tmp.baud_base = port->uartclk / 16;
-    tmp.close_delay = state->close_delay;
-    tmp.closing_wait = state->closing_wait;
-    tmp.custom_divisor = port->custom_divisor;
-    tmp.io_type = port->iotype;
+	tmp.irq = port->irq;
+	tmp.flags = port->flags;
+	tmp.xmit_fifo_size = port->fifosize;
+	tmp.baud_base = port->uartclk / 16;
+	tmp.close_delay = state->close_delay;
+	tmp.closing_wait = state->closing_wait;
+	tmp.custom_divisor = port->custom_divisor;
+	tmp.io_type = port->iotype;
 
-    if (copy_to_user(retinfo, &tmp, sizeof(*retinfo)))
-    {
-        return -EFAULT;
-    }
+	if(copy_to_user(retinfo, &tmp, sizeof(*retinfo))) {
+		return -EFAULT;
+	}
 
-    return 0;
+	return 0;
 }
 
 
 static int
 ser_set_info(
-			 struct ser_state *state,
-			 struct serial_struct *newinfo
-			 )
+    struct ser_state *state,
+    struct serial_struct *newinfo
+)
 {
-    struct serial_struct new_serial;
-    struct ser_port *port = state->port;
-    unsigned long new_port;
-    unsigned int change_irq;
-    unsigned int change_port;
-    unsigned int old_custom_divisor;
-    unsigned int closing_wait;
-    unsigned int close_delay;
-    unsigned int old_flags;
-    unsigned int new_flags;
-    int retval = 0;
-    if (copy_from_user(&new_serial, newinfo, sizeof(new_serial)))
-    {
-        return -EFAULT;
-    }
+	struct serial_struct new_serial;
+	struct ser_port *port = state->port;
+	unsigned long new_port;
+	unsigned int change_irq;
+	unsigned int change_port;
+	unsigned int old_custom_divisor;
+	unsigned int closing_wait;
+	unsigned int close_delay;
+	unsigned int old_flags;
+	unsigned int new_flags;
+	int retval = 0;
+	if(copy_from_user(&new_serial, newinfo, sizeof(new_serial))) {
+		return -EFAULT;
+	}
 
-    new_port = new_serial.port;
+	new_port = new_serial.port;
 
-    if (WCH_HIGH_BITS_OFFSET)
-    {
-        new_port += (unsigned long) new_serial.port_high << WCH_HIGH_BITS_OFFSET;
-    }
+	if(WCH_HIGH_BITS_OFFSET) {
+		new_port += (unsigned long) new_serial.port_high << WCH_HIGH_BITS_OFFSET;
+	}
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    new_serial.irq = irq_canonicalize(new_serial.irq);
+	new_serial.irq = irq_canonicalize(new_serial.irq);
 #endif
 
 	close_delay = new_serial.close_delay;
@@ -1099,208 +1000,185 @@ ser_set_info(
 
 	down(&state->sem);
 
-    change_irq  = new_serial.irq != port->irq;
+	change_irq  = new_serial.irq != port->irq;
 
-    change_port =   new_port != port->iobase ||
-                    new_serial.io_type != port->iotype ||
-                    new_serial.type != port->type;
+	change_port =   new_port != port->iobase ||
+	                new_serial.io_type != port->iotype ||
+	                new_serial.type != port->type;
 
-    old_flags = port->flags;
-    new_flags = new_serial.flags;
-    old_custom_divisor = port->custom_divisor;
+	old_flags = port->flags;
+	new_flags = new_serial.flags;
+	old_custom_divisor = port->custom_divisor;
 
-    if (!capable(CAP_SYS_ADMIN))
-    {
-        retval = -EPERM;
-        if (change_irq ||
-            change_port ||
-            (new_serial.baud_base != port->uartclk / 16) ||
-            (close_delay != state->close_delay) ||
-            (closing_wait != state->closing_wait) ||
-            (new_serial.xmit_fifo_size != port->fifosize) ||
-            (((new_flags ^ old_flags) & ~WCH_UPF_USR_MASK) != 0))
-        {
-            goto exit;
-        }
+	if(!capable(CAP_SYS_ADMIN)) {
+		retval = -EPERM;
+		if(change_irq ||
+		   change_port ||
+		   (new_serial.baud_base != port->uartclk / 16) ||
+		   (close_delay != state->close_delay) ||
+		   (closing_wait != state->closing_wait) ||
+		   (new_serial.xmit_fifo_size != port->fifosize) ||
+		   (((new_flags ^ old_flags) & ~WCH_UPF_USR_MASK) != 0)) {
+			goto exit;
+		}
 
-        port->flags = ((port->flags & ~WCH_UPF_USR_MASK) | (new_flags & WCH_UPF_USR_MASK));
-        port->custom_divisor = new_serial.custom_divisor;
-        goto check_and_exit;
-    }
+		port->flags = ((port->flags & ~WCH_UPF_USR_MASK) | (new_flags & WCH_UPF_USR_MASK));
+		port->custom_divisor = new_serial.custom_divisor;
+		goto check_and_exit;
+	}
 
-    if (change_port || change_irq)
-    {
-        retval = -EBUSY;
+	if(change_port || change_irq) {
+		retval = -EBUSY;
 
 
-        if (wch_ser_users(state) > 1)
-        {
-            goto exit;
-        }
+		if(wch_ser_users(state) > 1) {
+			goto exit;
+		}
 
-        ser_shutdown(state);
-    }
+		ser_shutdown(state);
+	}
 
-    if (change_port)
-    {
-        unsigned long old_iobase;
-        unsigned int old_type;
-        unsigned int old_iotype;
+	if(change_port) {
+		unsigned long old_iobase;
+		unsigned int old_type;
+		unsigned int old_iotype;
 
-        old_iobase = port->iobase;
-        old_type = port->type;
-        old_iotype = port->iotype;
+		old_iobase = port->iobase;
+		old_type = port->type;
+		old_iotype = port->iotype;
 
 
-        if (old_type != PORT_UNKNOWN)
-        {
-            wch_ser_release_io(port);
-        }
+		if(old_type != PORT_UNKNOWN) {
+			wch_ser_release_io(port);
+		}
 
-        port->iobase = new_port;
-        port->type = new_serial.type;
-        port->iotype = new_serial.io_type;
+		port->iobase = new_port;
+		port->type = new_serial.type;
+		port->iotype = new_serial.io_type;
 
-        retval = 0;
-    }
+		retval = 0;
+	}
 
-    port->irq = new_serial.irq;
-    port->uartclk = new_serial.baud_base * 16;
-    port->flags = ((port->flags & ~WCH_UPF_CHANGE_MASK) | (new_flags & WCH_UPF_CHANGE_MASK));
-    port->custom_divisor = new_serial.custom_divisor;
-    state->close_delay = close_delay;
-    state->closing_wait = closing_wait;
-    port->fifosize = new_serial.xmit_fifo_size;
+	port->irq = new_serial.irq;
+	port->uartclk = new_serial.baud_base * 16;
+	port->flags = ((port->flags & ~WCH_UPF_CHANGE_MASK) | (new_flags & WCH_UPF_CHANGE_MASK));
+	port->custom_divisor = new_serial.custom_divisor;
+	state->close_delay = close_delay;
+	state->closing_wait = closing_wait;
+	port->fifosize = new_serial.xmit_fifo_size;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    if (state->info->tty)
-    {
-        state->info->tty->low_latency = (port->flags & WCH_UPF_LOW_LATENCY) ? 1 : 0;
-    }
+	if(state->info->tty) {
+		state->info->tty->low_latency = (port->flags & WCH_UPF_LOW_LATENCY) ? 1 : 0;
+	}
 #endif
 check_and_exit:
-    retval = 0;
-    if (port->type == PORT_UNKNOWN)
-    {
-        goto exit;
-    }
+	retval = 0;
+	if(port->type == PORT_UNKNOWN) {
+		goto exit;
+	}
 
-    if (state->info->flags & WCH_UIF_INITIALIZED)
-    {
-        if (((old_flags ^ port->flags) & WCH_UPF_SPD_MASK) || old_custom_divisor != port->custom_divisor)
-        {
+	if(state->info->flags & WCH_UIF_INITIALIZED) {
+		if(((old_flags ^ port->flags) & WCH_UPF_SPD_MASK) || old_custom_divisor != port->custom_divisor) {
 
-            if (port->flags & WCH_UPF_SPD_MASK)
-            {
-                printk("WCH Info : %s sets custom speed on ttyWCH%d. This is deprecated.\n", current->comm, port->line);
-            }
-            ser_change_speed(state, NULL);
-        }
-    }
-    else
-    {
-        retval = ser_startup(state, 1);
-    }
+			if(port->flags & WCH_UPF_SPD_MASK) {
+				printk("WCH Info : %s sets custom speed on ttyWCH%d. This is deprecated.\n", current->comm, port->line);
+			}
+			ser_change_speed(state, NULL);
+		}
+	} else {
+		retval = ser_startup(state, 1);
+	}
 exit:
 	up(&state->sem);
 
-    return retval;
+	return retval;
 }
 
 
 static int
 ser_write_room(
-			   struct tty_struct *tty
-			   )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    int status = 0;
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return 0;
-    }
+	struct ser_state *state = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	int status = 0;
+	if(line >= wch_ser_port_total_cnt) {
+		return 0;
+	}
 
-    state = tty->driver_data;
+	state = tty->driver_data;
 
-    status = ser_circ_chars_free(&state->info->xmit);
-    return status;
+	status = ser_circ_chars_free(&state->info->xmit);
+	return status;
 }
 
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,10))
 static int
 ser_write(
-		  struct tty_struct *tty,
-		  const unsigned char *buf,
-		  int count
-		  )
+    struct tty_struct *tty,
+    const unsigned char *buf,
+    int count
+)
 #else
 static int
 ser_write(
-		  struct tty_struct *tty,
-		  int from_user,
-		  const unsigned char *buf,
-		  int count
-		  )
+    struct tty_struct *tty,
+    int from_user,
+    const unsigned char *buf,
+    int count
+)
 #endif
 {
-    struct ser_state *state = tty->driver_data;
-    struct ser_port *port = NULL;
-    struct circ_buf *circ = NULL;
+	struct ser_state *state = tty->driver_data;
+	struct ser_port *port = NULL;
+	struct circ_buf *circ = NULL;
 	unsigned long flags;
-    int c;
-    int ret = 0;
-    if (!state || !state->info)
-    {
-        return -EL3HLT;
-    }
+	int c;
+	int ret = 0;
+	if(!state || !state->info) {
+		return -EL3HLT;
+	}
 
-    port = state->port;
-    circ = &state->info->xmit;
+	port = state->port;
+	circ = &state->info->xmit;
 
-    if (!circ->buf)
-    {
-        return 0;
-    }
+	if(!circ->buf) {
+		return 0;
+	}
 
 	spin_lock_irqsave(&port->lock, flags);
-    while (1)
-    {
-        c = CIRC_SPACE_TO_END(circ->head, circ->tail, WCH_UART_XMIT_SIZE);
-        if (count < c)
-        {
-            c = count;
-        }
+	while(1) {
+		c = CIRC_SPACE_TO_END(circ->head, circ->tail, WCH_UART_XMIT_SIZE);
+		if(count < c) {
+			c = count;
+		}
 
-        if (c <= 0)
-        {
-            break;
-        }
+		if(c <= 0) {
+			break;
+		}
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,9))
-        memcpy(circ->buf + circ->head, buf, c);
+		memcpy(circ->buf + circ->head, buf, c);
 #else
-		if (from_user)
-		{
-			if (copy_from_user((circ->buf + circ->head), buf, c) == c)
-			{
+		if(from_user) {
+			if(copy_from_user((circ->buf + circ->head), buf, c) == c) {
 				ret = -EFAULT;
 				break;
 			}
-		}
-		else
-		{
+		} else {
 			memcpy(circ->buf + circ->head, buf, c);
 		}
 #endif
-        circ->head = (circ->head + c) & (WCH_UART_XMIT_SIZE - 1);
-        buf += c;
-        count -= c;
-        ret += c;
-    }
-    _ser_start(tty);
+		circ->head = (circ->head + c) & (WCH_UART_XMIT_SIZE - 1);
+		buf += c;
+		count -= c;
+		ret += c;
+	}
+	_ser_start(tty);
 	spin_unlock_irqrestore(&port->lock, flags);
 
-    return ret;
+	return ret;
 }
 
 /*
@@ -1339,64 +1217,60 @@ ser_get_lsr_info(
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 static int
 ser_tiocmget(
-	struct tty_struct *tty
-	)
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state;
-    struct ser_port *port;
-    int result = -EIO;
-    int line = WCH_SER_DEVNUM(tty);
+	struct ser_state *state;
+	struct ser_port *port;
+	int result = -EIO;
+	int line = WCH_SER_DEVNUM(tty);
 
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return 0;
-    }
+	if(line >= wch_ser_port_total_cnt) {
+		return 0;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    down(&state->sem);
+	down(&state->sem);
 
-    if (!(tty->flags & (1 << TTY_IO_ERROR)))
-    {
-        result = port->mctrl;
-        result |= wch_ser_get_mctrl(port);
-    }
+	if(!(tty->flags & (1 << TTY_IO_ERROR))) {
+		result = port->mctrl;
+		result |= wch_ser_get_mctrl(port);
+	}
 
 	up(&state->sem);
 
-    return result;
+	return result;
 }
 
 static int
 ser_tiocmset(
-	struct tty_struct *tty,
-	unsigned int set,
-	unsigned int clear
-	)
+    struct tty_struct *tty,
+    unsigned int set,
+    unsigned int clear
+)
 {
-    struct ser_state *state;
-    struct ser_port *port;
-    int ret = -EIO;
-    int line = WCH_SER_DEVNUM(tty);
+	struct ser_state *state;
+	struct ser_port *port;
+	int ret = -EIO;
+	int line = WCH_SER_DEVNUM(tty);
 
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return 0;
-    }
+	if(line >= wch_ser_port_total_cnt) {
+		return 0;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
 	down(&state->sem);
 
-    if (!(tty->flags & (1 << TTY_IO_ERROR)))
-    {
-        ser_update_mctrl(port, set, clear);
-        ret = 0;
-    }
+	if(!(tty->flags & (1 << TTY_IO_ERROR))) {
+		ser_update_mctrl(port, set, clear);
+		ret = 0;
+	}
 
-    up(&state->sem);
+	up(&state->sem);
 
 	return ret;
 }
@@ -1404,101 +1278,94 @@ ser_tiocmset(
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 static int
 ser_tiocmget(
-			 struct tty_struct *tty,
-			 struct file *file
-			 )
+    struct tty_struct *tty,
+    struct file *file
+)
 {
-    struct ser_state *state;
-    struct ser_port *port;
-    int result = -EIO;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return 0;
-    }
+	struct ser_state *state;
+	struct ser_port *port;
+	int result = -EIO;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return 0;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    down(&state->sem);
+	down(&state->sem);
 
-    if ((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR)))
-    {
-        result = port->mctrl;
-        result |= wch_ser_get_mctrl(port);
-    }
+	if((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR))) {
+		result = port->mctrl;
+		result |= wch_ser_get_mctrl(port);
+	}
 
 	up(&state->sem);
 
-    return result;
+	return result;
 }
 
 
 static int
 ser_tiocmset(
-			 struct tty_struct *tty,
-			 struct file *file,
-			 unsigned int set,
-			 unsigned int clear
-			 )
+    struct tty_struct *tty,
+    struct file *file,
+    unsigned int set,
+    unsigned int clear
+)
 {
-    struct ser_state *state;
-    struct ser_port *port;
-    int ret = -EIO;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return 0;
-    }
+	struct ser_state *state;
+	struct ser_port *port;
+	int ret = -EIO;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return 0;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
 	down(&state->sem);
 
-    if ((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR)))
-    {
-        ser_update_mctrl(port, set, clear);
-        ret = 0;
-    }
+	if((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR))) {
+		ser_update_mctrl(port, set, clear);
+		ret = 0;
+	}
 
 	up(&state->sem);
 
-    return ret;
+	return ret;
 }
 
 
 #else
 static int
 ser_get_modem_info(
-				   struct ser_state *state,
-				   unsigned int *value
-				   )
+    struct ser_state *state,
+    unsigned int *value
+)
 {
-    struct ser_port *port = NULL;
-    int line;
-    unsigned int result;
-    if (!state)
-    {
-        return -EIO;
-    }
+	struct ser_port *port = NULL;
+	int line;
+	unsigned int result;
+	if(!state) {
+		return -EIO;
+	}
 
-    port = state->port;
+	port = state->port;
 
-    if (!port)
-    {
-        return -EIO;
-    }
+	if(!port) {
+		return -EIO;
+	}
 
-    line = port->line;
+	line = port->line;
 
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return -EIO;
-    }
+	if(line >= wch_ser_port_total_cnt) {
+		return -EIO;
+	}
 
-    result = port->mctrl;
-    result |= wch_ser_get_mctrl(port);
+	result = port->mctrl;
+	result |= wch_ser_get_mctrl(port);
 
 	put_user(result, (unsigned long *)value);
 	return 0;
@@ -1507,112 +1374,89 @@ ser_get_modem_info(
 
 static int
 ser_set_modem_info(
-				   struct ser_state *state,
-				   unsigned int cmd,
-				   unsigned int *value
-				   )
+    struct ser_state *state,
+    unsigned int cmd,
+    unsigned int *value
+)
 {
-    struct ser_port *port = NULL;
-    int line;
-    unsigned int set = 0;
-    unsigned int clr = 0;
+	struct ser_port *port = NULL;
+	int line;
+	unsigned int set = 0;
+	unsigned int clr = 0;
 	unsigned int arg;
-    if (!state)
-    {
-        return -EIO;
-    }
+	if(!state) {
+		return -EIO;
+	}
 
-    port = state->port;
+	port = state->port;
 
-    if (!port)
-    {
-        return -EIO;
-    }
+	if(!port) {
+		return -EIO;
+	}
 
-    line = port->line;
+	line = port->line;
 
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return -EIO;
-    }
+	if(line >= wch_ser_port_total_cnt) {
+		return -EIO;
+	}
 
-	get_user(arg,(unsigned long *)value);
+	get_user(arg, (unsigned long *)value);
 
-	switch (cmd)
-	{
-	case TIOCMBIS:
-        {
-            if (arg & TIOCM_RTS)
-            {
-				set |= TIOCM_RTS;
-            }
+	switch(cmd) {
+	case TIOCMBIS: {
+		if(arg & TIOCM_RTS) {
+			set |= TIOCM_RTS;
+		}
 
-			if (arg & TIOCM_DTR)
-            {
-				set |= TIOCM_DTR;
-            }
+		if(arg & TIOCM_DTR) {
+			set |= TIOCM_DTR;
+		}
 
-            if (arg & TIOCM_LOOP)
-            {
-                set |= TIOCM_LOOP;
-            }
-			break;
-        }
+		if(arg & TIOCM_LOOP) {
+			set |= TIOCM_LOOP;
+		}
+		break;
+	}
 
-	case TIOCMBIC:
-        {
-			if (arg & TIOCM_RTS)
-            {
-				clr |= TIOCM_RTS;
-            }
+	case TIOCMBIC: {
+		if(arg & TIOCM_RTS) {
+			clr |= TIOCM_RTS;
+		}
 
-			if (arg & TIOCM_DTR)
-            {
-				clr |= TIOCM_DTR;
-            }
+		if(arg & TIOCM_DTR) {
+			clr |= TIOCM_DTR;
+		}
 
-            if (arg & TIOCM_LOOP)
-            {
-                clr |= TIOCM_LOOP;
-            }
-			break;
-        }
+		if(arg & TIOCM_LOOP) {
+			clr |= TIOCM_LOOP;
+		}
+		break;
+	}
 
-	case TIOCMSET:
-        {
-			if (arg & TIOCM_RTS)
-            {
-				set |= TIOCM_RTS;
-            }
-            else
-            {
-                clr |= TIOCM_RTS;
-            }
+	case TIOCMSET: {
+		if(arg & TIOCM_RTS) {
+			set |= TIOCM_RTS;
+		} else {
+			clr |= TIOCM_RTS;
+		}
 
-			if (arg & TIOCM_DTR)
-            {
-				set |= TIOCM_DTR;
-            }
-            else
-            {
-                clr |= TIOCM_DTR;
-            }
+		if(arg & TIOCM_DTR) {
+			set |= TIOCM_DTR;
+		} else {
+			clr |= TIOCM_DTR;
+		}
 
-            if (arg & TIOCM_LOOP)
-            {
-                set |= TIOCM_LOOP;
-            }
-            else
-            {
-                clr |= TIOCM_LOOP;
-            }
-			break;
-        }
+		if(arg & TIOCM_LOOP) {
+			set |= TIOCM_LOOP;
+		} else {
+			clr |= TIOCM_LOOP;
+		}
+		break;
+	}
 
-	default:
-        {
-            return -EINVAL;
-        }
+	default: {
+		return -EINVAL;
+	}
 	}
 
 	ser_update_mctrl(port, set, clr);
@@ -1624,38 +1468,36 @@ ser_set_modem_info(
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
 static int
 ser_break_ctl(
-			  struct tty_struct *tty,
-			  int break_state
-			  )
+    struct tty_struct *tty,
+    int break_state
+)
 #else
 static void
 ser_break_ctl(
-			  struct tty_struct *tty,
-			  int break_state
-			  )
+    struct tty_struct *tty,
+    int break_state
+)
 #endif
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
-        return 0;
+		return 0;
 #else
 		return;
 #endif
-    }
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    down(&state->sem);
+	down(&state->sem);
 
-    if (port->type != PORT_UNKNOWN)
-    {
-        wch_ser_break_ctl(port, break_state);
-    }
+	if(port->type != PORT_UNKNOWN) {
+		wch_ser_break_ctl(port, break_state);
+	}
 
 	up(&state->sem);
 
@@ -1667,293 +1509,267 @@ ser_break_ctl(
 
 static int
 ser_wait_modem_status(
-					  struct ser_state *state,
-					  unsigned long arg
-					  )
+    struct ser_state *state,
+    unsigned long arg
+)
 {
-    struct ser_port *port = state->port;
-    DECLARE_WAITQUEUE(wait, current);
-    struct ser_icount cprev;
-    struct ser_icount cnow;
-    int ret = 0;
-    spin_lock_irq(&port->lock);
-    memcpy(&cprev, &port->icount, sizeof(struct ser_icount));
+	struct ser_port *port = state->port;
+	DECLARE_WAITQUEUE(wait, current);
+	struct ser_icount cprev;
+	struct ser_icount cnow;
+	int ret = 0;
+	spin_lock_irq(&port->lock);
+	memcpy(&cprev, &port->icount, sizeof(struct ser_icount));
 
-    wch_ser_enable_ms(port);
+	wch_ser_enable_ms(port);
 
-    spin_unlock_irq(&port->lock);
+	spin_unlock_irq(&port->lock);
 
-    add_wait_queue(&state->info->delta_msr_wait, &wait);
+	add_wait_queue(&state->info->delta_msr_wait, &wait);
 
-    for (;;)
-    {
-        spin_lock_irq(&port->lock);
-        memcpy(&cnow, &port->icount, sizeof(struct ser_icount));
-        spin_unlock_irq(&port->lock);
+	for(;;) {
+		spin_lock_irq(&port->lock);
+		memcpy(&cnow, &port->icount, sizeof(struct ser_icount));
+		spin_unlock_irq(&port->lock);
 
-        set_current_state(TASK_INTERRUPTIBLE);
+		set_current_state(TASK_INTERRUPTIBLE);
 
-        if (((arg & TIOCM_RNG) && (cnow.rng != cprev.rng)) ||
-            ((arg & TIOCM_DSR) && (cnow.dsr != cprev.dsr)) ||
-            ((arg & TIOCM_CD)  && (cnow.dcd != cprev.dcd)) ||
-            ((arg & TIOCM_CTS) && (cnow.cts != cprev.cts)))
-        {
-            ret = 0;
-            break;
-        }
+		if(((arg & TIOCM_RNG) && (cnow.rng != cprev.rng)) ||
+		   ((arg & TIOCM_DSR) && (cnow.dsr != cprev.dsr)) ||
+		   ((arg & TIOCM_CD)  && (cnow.dcd != cprev.dcd)) ||
+		   ((arg & TIOCM_CTS) && (cnow.cts != cprev.cts))) {
+			ret = 0;
+			break;
+		}
 
-        schedule();
+		schedule();
 
 
-        if (signal_pending(current))
-        {
-            ret = -ERESTARTSYS;
-            break;
-        }
+		if(signal_pending(current)) {
+			ret = -ERESTARTSYS;
+			break;
+		}
 
-        cprev = cnow;
-    }
+		cprev = cnow;
+	}
 
-    current->state = TASK_RUNNING;
-    remove_wait_queue(&state->info->delta_msr_wait, &wait);
-    return ret;
+	current->state = TASK_RUNNING;
+	remove_wait_queue(&state->info->delta_msr_wait, &wait);
+	return ret;
 }
 
 
 static int
 ser_get_count(
-			  struct ser_state *state,
-			  struct serial_icounter_struct *icnt
-			  )
+    struct ser_state *state,
+    struct serial_icounter_struct *icnt
+)
 {
-    struct serial_icounter_struct icount;
-    struct ser_icount cnow;
-    struct ser_port *port = state->port;
-    spin_lock_irq(&port->lock);
-    memcpy(&cnow, &port->icount, sizeof(struct ser_icount));
-    spin_unlock_irq(&port->lock);
+	struct serial_icounter_struct icount;
+	struct ser_icount cnow;
+	struct ser_port *port = state->port;
+	spin_lock_irq(&port->lock);
+	memcpy(&cnow, &port->icount, sizeof(struct ser_icount));
+	spin_unlock_irq(&port->lock);
 
-    icount.cts = cnow.cts;
-    icount.dsr = cnow.dsr;
-    icount.rng = cnow.rng;
-    icount.dcd = cnow.dcd;
-    icount.rx = cnow.rx;
-    icount.tx = cnow.tx;
-    icount.frame = cnow.frame;
-    icount.overrun = cnow.overrun;
-    icount.parity = cnow.parity;
-    icount.brk = cnow.brk;
-    icount.buf_overrun = cnow.buf_overrun;
+	icount.cts = cnow.cts;
+	icount.dsr = cnow.dsr;
+	icount.rng = cnow.rng;
+	icount.dcd = cnow.dcd;
+	icount.rx = cnow.rx;
+	icount.tx = cnow.tx;
+	icount.frame = cnow.frame;
+	icount.overrun = cnow.overrun;
+	icount.parity = cnow.parity;
+	icount.brk = cnow.brk;
+	icount.buf_overrun = cnow.buf_overrun;
 
-    return copy_to_user(icnt, &icount, sizeof(icount)) ? -EFAULT : 0;
+	return copy_to_user(icnt, &icount, sizeof(icount)) ? -EFAULT : 0;
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 static int
 ser_ioctl(
-	struct tty_struct *tty,
-	unsigned int cmd,
-	unsigned long arg
-	)
+    struct tty_struct *tty,
+    unsigned int cmd,
+    unsigned long arg
+)
 #else
 static int
 ser_ioctl(
-	struct tty_struct *tty,
-	struct file *filp,
-	unsigned int cmd,
-	unsigned long arg
-	)
+    struct tty_struct *tty,
+    struct file *filp,
+    unsigned int cmd,
+    unsigned long arg
+)
 #endif
 {
-    struct ser_state *state = NULL;
-    int ret = -ENOIOCTLCMD;
-    int line = WCH_SER_DEVNUM(tty);
+	struct ser_state *state = NULL;
+	int ret = -ENOIOCTLCMD;
+	int line = WCH_SER_DEVNUM(tty);
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,0))
-    int status = 0;
+	int status = 0;
 #endif
-    if (line < wch_ser_port_total_cnt)
-    {
-        state = tty->driver_data;
-    }
+	if(line < wch_ser_port_total_cnt) {
+		state = tty->driver_data;
+	}
 
 
-    switch (cmd)
-    {
-	case TIOCGSERIAL:
-        {
-			if (line < wch_ser_port_total_cnt)
-			{
-				ret = ser_get_info(state, (struct serial_struct *)arg);
-            }
-            break;
+	switch(cmd) {
+	case TIOCGSERIAL: {
+		if(line < wch_ser_port_total_cnt) {
+			ret = ser_get_info(state, (struct serial_struct *)arg);
 		}
+		break;
+	}
 
 
-	case TIOCSSERIAL:
-        {
-			if (line < wch_ser_port_total_cnt)
-			{
-				state->port->setserial_flag = WCH_SER_BAUD_SETSERIAL;
-				ret = ser_set_info(state, (struct serial_struct *)arg);
-            }
-            break;
+	case TIOCSSERIAL: {
+		if(line < wch_ser_port_total_cnt) {
+			state->port->setserial_flag = WCH_SER_BAUD_SETSERIAL;
+			ret = ser_set_info(state, (struct serial_struct *)arg);
 		}
+		break;
+	}
 
-	case TCGETS:
-		{
+	case TCGETS: {
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 11, 0))
-			struct ktermios kterm;
-			mutex_lock(&tty->throttle_mutex);
-			kterm = tty->termios;
-			mutex_unlock(&tty->throttle_mutex);
+		struct ktermios kterm;
+		mutex_lock(&tty->throttle_mutex);
+		kterm = tty->termios;
+		mutex_unlock(&tty->throttle_mutex);
 
-			if(kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
-				ret = -EFAULT;
-			else
-				ret = 0;
+		if(kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
+			ret = -EFAULT;
+		else
+			ret = 0;
 #elif (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-			struct ktermios kterm;
-			mutex_lock(&tty->termios_mutex);
-			kterm = tty->termios;
-			mutex_unlock(&tty->termios_mutex);
+		struct ktermios kterm;
+		mutex_lock(&tty->termios_mutex);
+		kterm = tty->termios;
+		mutex_unlock(&tty->termios_mutex);
 
-			if(kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
-				ret = -EFAULT;
-			else
-				ret = 0;
+		if(kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
+			ret = -EFAULT;
+		else
+			ret = 0;
 #elif (LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 19))
-			struct ktermios * kterm;
-                        mutex_lock(&tty->termios_mutex);
-                        kterm = tty->termios;
-                        mutex_unlock(&tty->termios_mutex);
+		struct ktermios * kterm;
+		mutex_lock(&tty->termios_mutex);
+		kterm = tty->termios;
+		mutex_unlock(&tty->termios_mutex);
 
-                        if(kernel_termios_to_user_termios_1((struct termios __user *)arg, kterm))
-                                ret = -EFAULT;
-                        else
-                                ret = 0;
+		if(kernel_termios_to_user_termios_1((struct termios __user *)arg, kterm))
+			ret = -EFAULT;
+		else
+			ret = 0;
 
 
 #endif
-			break;
-		}
+		break;
+	}
 
-	case TCSETS:
-		{
-			if (line < wch_ser_port_total_cnt)
-			{
-				state->port->flags &= ~(WCH_UPF_SPD_HI | WCH_UPF_SPD_VHI | WCH_UPF_SPD_SHI | WCH_UPF_SPD_WARP);
-				state->port->setserial_flag = WCH_SER_BAUD_NOTSETSER;
-				ser_update_termios(state);
-			}
-			break;
+	case TCSETS: {
+		if(line < wch_ser_port_total_cnt) {
+			state->port->flags &= ~(WCH_UPF_SPD_HI | WCH_UPF_SPD_VHI | WCH_UPF_SPD_SHI | WCH_UPF_SPD_WARP);
+			state->port->setserial_flag = WCH_SER_BAUD_NOTSETSER;
+			ser_update_termios(state);
 		}
-	case TIOCSRS485:
-		{
-			ret = 0;
-			break;
-		}
+		break;
+	}
+	case TIOCSRS485: {
+		ret = 0;
+		break;
+	}
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,0))
-	case TIOCMGET:
-		{
-			if (line < wch_ser_port_total_cnt)
-			{
-				ret = verify_area(VERIFY_WRITE, (void *)arg, sizeof(unsigned int));
+	case TIOCMGET: {
+		if(line < wch_ser_port_total_cnt) {
+			ret = verify_area(VERIFY_WRITE, (void *)arg, sizeof(unsigned int));
 
-				if (ret)
-				{
-					return ret;
-				}
-
-				status = ser_get_modem_info(state, (unsigned int *)arg);
-				return status;
+			if(ret) {
+				return ret;
 			}
-			break;
+
+			status = ser_get_modem_info(state, (unsigned int *)arg);
+			return status;
 		}
+		break;
+	}
 
 
 	case TIOCMBIS:
 	case TIOCMBIC:
-	case TIOCMSET:
-		{
-			if (line < wch_ser_port_total_cnt)
-			{
-				status = ser_set_modem_info(state, cmd, (unsigned int *)arg);
-				return status;
-			}
-			break;
+	case TIOCMSET: {
+		if(line < wch_ser_port_total_cnt) {
+			status = ser_set_modem_info(state, cmd, (unsigned int *)arg);
+			return status;
 		}
+		break;
+	}
 #endif
 
 
 	case TIOCSERGWILD:
-	case TIOCSERSWILD:
-        {
-			if (line < wch_ser_port_total_cnt)
-			{
-				ret = 0;
-			}
-            break;
-        }
+	case TIOCSERSWILD: {
+		if(line < wch_ser_port_total_cnt) {
+			ret = 0;
+		}
+		break;
+	}
 	case TIOCMIWAIT:
-		if (line < wch_ser_port_total_cnt)
-		{
+		if(line < wch_ser_port_total_cnt) {
 			ret = ser_wait_modem_status(state, arg);
 		}
 		break;
 
 
 	case TIOCGICOUNT:
-		if (line < wch_ser_port_total_cnt)
-		{
+		if(line < wch_ser_port_total_cnt) {
 			ret = ser_get_count(state, (struct serial_icounter_struct *)arg);
 		}
 		break;
 
- }
+	}
 
-    if (ret != -ENOIOCTLCMD)
-    {
-        goto out;
-    }
+	if(ret != -ENOIOCTLCMD) {
+		goto out;
+	}
 
-    if (tty->flags & (1 << TTY_IO_ERROR))
-    {
-        ret = -EIO;
-        goto out;
-    }
+	if(tty->flags & (1 << TTY_IO_ERROR)) {
+		ret = -EIO;
+		goto out;
+	}
 out:
-    return ret;
+	return ret;
 
 }
 
 
 static void
 ser_hangup(
-		   struct tty_struct *tty
-		   )
+    struct tty_struct *tty
+)
 {
-    struct ser_state *state = NULL;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	struct ser_state *state = NULL;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
+	state = tty->driver_data;
 
 	down(&state->sem);
 
-    if (state->info && state->info->flags & WCH_UIF_NORMAL_ACTIVE)
-    {
-        ser_flush_buffer(tty);
-        ser_shutdown(state);
-        state->count = 0;
-        state->info->flags &= ~WCH_UIF_NORMAL_ACTIVE;
-        state->info->tty = NULL;
-        wake_up_interruptible(&state->info->open_wait);
-        wake_up_interruptible(&state->info->delta_msr_wait);
-    }
+	if(state->info && state->info->flags & WCH_UIF_NORMAL_ACTIVE) {
+		ser_flush_buffer(tty);
+		ser_shutdown(state);
+		state->count = 0;
+		state->info->flags &= ~WCH_UIF_NORMAL_ACTIVE;
+		state->info->tty = NULL;
+		wake_up_interruptible(&state->info->open_wait);
+		wake_up_interruptible(&state->info->delta_msr_wait);
+	}
 
 	up(&state->sem);
 }
@@ -1961,990 +1777,894 @@ ser_hangup(
 
 unsigned int
 ser_get_divisor(
-				struct ser_port *port,
-				unsigned int baud
-				)
+    struct ser_port *port,
+    unsigned int baud
+)
 {
-    unsigned int quot;
-    if (baud == 38400 && (port->flags & WCH_UPF_SPD_MASK) == WCH_UPF_SPD_CUST)
-    {
-        quot = port->custom_divisor;
-    }
-    else
-    {
-        quot = port->uartclk / (16 * baud);
-    }
+	unsigned int quot;
+	if(baud == 38400 && (port->flags & WCH_UPF_SPD_MASK) == WCH_UPF_SPD_CUST) {
+		quot = port->custom_divisor;
+	} else {
+		if(baud > port->baud_base)
+			quot = port->uartclk * 24 / 16 / baud;
+		else
+			quot = port->uartclk / 16 / baud;
+	}
 
-
-    return quot;
+	return quot;
 }
 
 unsigned int
 ser_get_baud_rate(
-				  struct ser_port *port,
-				  struct WCHTERMIOS *termios,
-				  struct WCHTERMIOS *old,
-				  unsigned int min,
-				  unsigned int max
-				  )
+    struct ser_port *port,
+    struct WCHTERMIOS *termios,
+    struct WCHTERMIOS *old,
+    unsigned int min,
+    unsigned int max
+)
 {
-    unsigned int try;
-    unsigned int baud;
-    unsigned int altbaud = 38400;
-    int hung_up = 0;
-    unsigned int flags = port->flags & WCH_UPF_SPD_MASK;
+	unsigned int try;
+	unsigned int baud;
+	unsigned int altbaud = 38400;
+	int hung_up = 0;
+	unsigned int flags = port->flags & WCH_UPF_SPD_MASK;
 
-    if (port->flags & WCH_UPF_SPD_MASK)
-    {
-        altbaud = 38400;
-        if (flags == WCH_UPF_SPD_HI)
-        {
-            altbaud = 57600;
-        }
-
-        if (flags == WCH_UPF_SPD_VHI)
-        {
-            altbaud = 115200;
-        }
-
-        if (flags == WCH_UPF_SPD_SHI)
-        {
-            altbaud = 230400;
-        }
-
-        if (flags == WCH_UPF_SPD_WARP)
-        {
-            altbaud = 460800;
-        }
-    }
-
-    for (try = 0; try < 2; try++)
-    {
-    	baud = tty_termios_baud_rate(termios);
-
-        if (try == 0 && baud == 38400)
-			baud = altbaud;
-
-        if (baud == 0)
-        {
-            hung_up = 1;
-            baud = 9600;
-        }
-
-        if (baud >= min && baud <= max)
-        {
-            return baud;
-        }
-
-        termios->c_cflag &= ~CBAUD;
-        if (old)
-        {
-			baud = tty_termios_baud_rate(old);
-			if (!hung_up)
-				tty_termios_encode_baud_rate(termios,
-								baud, baud);
-			old = NULL;
-			continue;
+	if(port->flags & WCH_UPF_SPD_MASK) {
+		altbaud = 38400;
+		if(flags == WCH_UPF_SPD_HI) {
+			altbaud = 57600;
 		}
-        /*
-		 * As a last resort, if the range cannot be met then clip to
-		 * the nearest chip supported rate.
-		 */
-		if (!hung_up) {
-			if (baud <= min)
-				tty_termios_encode_baud_rate(termios,
-							min + 1, min + 1);
-			else
-				tty_termios_encode_baud_rate(termios,
-							max - 1, max - 1);
-		}
-    }
 
-    return 0;
+		if(flags == WCH_UPF_SPD_VHI) {
+			altbaud = 115200;
+		}
+
+		if(flags == WCH_UPF_SPD_SHI) {
+			altbaud = 230400;
+		}
+
+		if(flags == WCH_UPF_SPD_WARP) {
+			altbaud = 460800;
+		}
+	}
+
+	for(try = 0; try < 2; try++) {
+					baud = tty_termios_baud_rate(termios);
+
+					if(try == 0 && baud == 38400)
+							baud = altbaud;
+
+					if(baud == 0) {
+						hung_up = 1;
+						baud = 9600;
+					}
+
+					if(baud >= min && baud <= max) {
+						return baud;
+					}
+
+					termios->c_cflag &= ~CBAUD;
+					if(old) {
+						baud = tty_termios_baud_rate(old);
+						if(!hung_up)
+							tty_termios_encode_baud_rate(termios,
+							                             baud, baud);
+						old = NULL;
+						continue;
+					}
+					/*
+					 * As a last resort, if the range cannot be met then clip to
+					 * the nearest chip supported rate.
+					 */
+					if(!hung_up) {
+						if(baud <= min)
+							tty_termios_encode_baud_rate(termios,
+							                             min + 1, min + 1);
+						else
+							tty_termios_encode_baud_rate(termios,
+							                             max - 1, max - 1);
+					}
+				}
+
+	return 0;
 }
 
 
 static void
 ser_change_speed(
-				 struct ser_state *state,
-				 struct WCHTERMIOS *old_termios
-				 )
+    struct ser_state *state,
+    struct WCHTERMIOS *old_termios
+)
 {
-    struct tty_struct *tty = state->info->tty;
-    struct ser_port *port = state->port;
+	struct tty_struct *tty = state->info->tty;
+	struct ser_port *port = state->port;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    struct WCHTERMIOS *termios;
-    if (!tty || !tty->termios || port->type == PORT_UNKNOWN)
-    {
-        return;
-    }
+	struct WCHTERMIOS *termios;
+	if(!tty || !tty->termios || port->type == PORT_UNKNOWN) {
+		return;
+	}
 
-    termios = tty->termios;
+	termios = tty->termios;
 
-    if (termios->c_cflag & CRTSCTS)
-    {
-        state->info->flags |= WCH_UIF_CTS_FLOW;
-    }
-    else
-    {
-        state->info->flags &= ~WCH_UIF_CTS_FLOW;
-    }
+	if(termios->c_cflag & CRTSCTS) {
+		state->info->flags |= WCH_UIF_CTS_FLOW;
+	} else {
+		state->info->flags &= ~WCH_UIF_CTS_FLOW;
+	}
 
-    if (termios->c_cflag & CLOCAL)
-    {
-        state->info->flags &= ~WCH_UIF_CHECK_CD;
-    }
-    else
-    {
-        state->info->flags |= WCH_UIF_CHECK_CD;
-    }
-    wch_ser_set_termios(port, termios, old_termios);
+	if(termios->c_cflag & CLOCAL) {
+		state->info->flags &= ~WCH_UIF_CHECK_CD;
+	} else {
+		state->info->flags |= WCH_UIF_CHECK_CD;
+	}
+	wch_ser_set_termios(port, termios, old_termios);
 #else
-    struct WCHTERMIOS termios;
-    if (!tty || port->type == PORT_UNKNOWN)
-    {
-        return;
-    }
-    termios = tty->termios;
-    if (termios.c_cflag & CRTSCTS)
-    {
-        state->info->flags |= WCH_UIF_CTS_FLOW;
-    }
-    else
-    {
-        state->info->flags &= ~WCH_UIF_CTS_FLOW;
-    }
+	struct WCHTERMIOS termios;
+	if(!tty || port->type == PORT_UNKNOWN) {
+		return;
+	}
+	termios = tty->termios;
+	if(termios.c_cflag & CRTSCTS) {
+		state->info->flags |= WCH_UIF_CTS_FLOW;
+	} else {
+		state->info->flags &= ~WCH_UIF_CTS_FLOW;
+	}
 
-    if (termios.c_cflag & CLOCAL)
-    {
-        state->info->flags &= ~WCH_UIF_CHECK_CD;
-    }
-    else
-    {
-        state->info->flags |= WCH_UIF_CHECK_CD;
-    }
-    wch_ser_set_termios(port, &termios, old_termios);
+	if(termios.c_cflag & CLOCAL) {
+		state->info->flags &= ~WCH_UIF_CHECK_CD;
+	} else {
+		state->info->flags |= WCH_UIF_CHECK_CD;
+	}
+	wch_ser_set_termios(port, &termios, old_termios);
 #endif
 }
 
 
 static void
 ser_set_termios(
-				struct tty_struct *tty,
-				struct WCHTERMIOS *old_termios
-				)
+    struct tty_struct *tty,
+    struct WCHTERMIOS *old_termios
+)
 {
-    struct ser_state *state;
-    unsigned long flags;
+	struct ser_state *state;
+	unsigned long flags;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    unsigned int cflag = tty->termios->c_cflag;
+	unsigned int cflag = tty->termios->c_cflag;
 #else
-    unsigned int cflag = tty->termios.c_cflag;
+	unsigned int cflag = tty->termios.c_cflag;
 #endif
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
+	state = tty->driver_data;
 
 #define RELEVANT_IFLAG(iflag)   ((iflag) & (IGNBRK|BRKINT|IGNPAR|PARMRK|INPCK))
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-    if ((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios->c_iflag ^ old_termios->c_iflag) == 0)
+	if((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios->c_iflag ^ old_termios->c_iflag) == 0)
 #else
-    if ((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios.c_iflag ^ old_termios->c_iflag) == 0)
+	if((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios.c_iflag ^ old_termios->c_iflag) == 0)
 #endif
-    {
-        return;
-    }
+	{
+		return;
+	}
 
-    ser_change_speed(state, old_termios);
+	ser_change_speed(state, old_termios);
 
 	/* Drop RTS and DTR */
-	if ((cflag & CBAUD) == B0)
-    {
-        clear_mctrl(state->port, TIOCM_RTS | TIOCM_DTR);
-    }
-	else {
+	if((cflag & CBAUD) == B0) {
+		clear_mctrl(state->port, TIOCM_RTS | TIOCM_DTR);
+	} else {
 		/* Ensure RTS and DTR are raised when baudrate changed from 0 */
-		if (old_termios && ((old_termios->c_cflag & CBAUD) == B0)) {
+		if(old_termios && ((old_termios->c_cflag & CBAUD) == B0)) {
 			unsigned int mask = TIOCM_DTR;
-			if (!(cflag & CRTSCTS) || !test_bit(TTY_THROTTLED, &tty->flags))
-			{
+			if(!(cflag & CRTSCTS) || !test_bit(TTY_THROTTLED, &tty->flags)) {
 				mask |= TIOCM_RTS;
 			}
 			set_mctrl(state->port, mask);
 		}
-    }
+	}
 
-    if ((old_termios->c_cflag & CRTSCTS) && !(cflag & CRTSCTS))
-    {
-        spin_lock_irqsave(&state->port->lock, flags);
-        tty->hw_stopped = 0;
-        _ser_start(tty);
-        spin_unlock_irqrestore(&state->port->lock, flags);
-    }
+	if((old_termios->c_cflag & CRTSCTS) && !(cflag & CRTSCTS)) {
+		spin_lock_irqsave(&state->port->lock, flags);
+		tty->hw_stopped = 0;
+		_ser_start(tty);
+		spin_unlock_irqrestore(&state->port->lock, flags);
+	}
 
 }
 
 
 static void
 ser_update_termios(
-				   struct ser_state *state
-				   )
+    struct ser_state *state
+)
 {
-    struct tty_struct *tty = state->info->tty;
+	struct tty_struct *tty = state->info->tty;
 //    struct ser_port *port = state->port;
 
-    if (!(tty->flags & (1 << TTY_IO_ERROR)))
-    {
-        ser_change_speed(state, NULL);
+	if(!(tty->flags & (1 << TTY_IO_ERROR))) {
+		ser_change_speed(state, NULL);
 		// disclaimed on 20200929
 		/*
-#if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-        if (tty->termios->c_cflag & CBAUD)
-#else
-        if (tty->termios.c_cflag & CBAUD)
-#endif
-        {
-            set_mctrl(port, TIOCM_DTR | TIOCM_RTS);
-        }
-        */
-    }
+		#if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
+		if (tty->termios->c_cflag & CBAUD)
+		#else
+		if (tty->termios.c_cflag & CBAUD)
+		#endif
+		{
+		    set_mctrl(port, TIOCM_DTR | TIOCM_RTS);
+		}
+		*/
+	}
 }
 
 
 static void
 ser_update_timeout(
-				   struct ser_port *port,
-				   unsigned int cflag,
-				   unsigned int baud
-				   )
+    struct ser_port *port,
+    unsigned int cflag,
+    unsigned int baud
+)
 {
-    unsigned int bits;
-    switch (cflag & CSIZE)
-    {
-        case CS5:
-            bits = 7;
-            break;
+	unsigned int bits;
+	switch(cflag & CSIZE) {
+	case CS5:
+		bits = 7;
+		break;
 
-        case CS6:
-            bits = 8;
-            break;
+	case CS6:
+		bits = 8;
+		break;
 
-        case CS7:
-            bits = 9;
-            break;
+	case CS7:
+		bits = 9;
+		break;
 
-        default:
-            bits = 10;
-            break;
-    }
+	default:
+		bits = 10;
+		break;
+	}
 
-    if (cflag & CSTOPB)
-    {
-        bits++;
-    }
+	if(cflag & CSTOPB) {
+		bits++;
+	}
 
-    if (cflag & PARENB)
-    {
-        bits++;
-    }
+	if(cflag & PARENB) {
+		bits++;
+	}
 
-    bits = bits * port->fifosize;
+	bits = bits * port->fifosize;
 
-    port->timeout = (HZ * bits) / baud + HZ/50;
+	port->timeout = (HZ * bits) / baud + HZ / 50;
 }
 
 
 static struct
 ser_state *ser_get(
-				   struct ser_driver *drv,
-				   int line
-				   )
+    struct ser_driver *drv,
+    int line
+)
 {
-    struct ser_state *state = NULL;
+	struct ser_state *state = NULL;
 
 	down(&ser_port_sem);
 
-    state = drv->state + line;
+	state = drv->state + line;
 
-	if (down_interruptible(&state->sem))
-    {
-        state = ERR_PTR(-ERESTARTSYS);
-        goto out;
-    }
+	if(down_interruptible(&state->sem)) {
+		state = ERR_PTR(-ERESTARTSYS);
+		goto out;
+	}
 
-    state->count++;
+	state->count++;
 
-    if (!state->port)
-    {
-        state->count--;
+	if(!state->port) {
+		state->count--;
 		up(&state->sem);
-        state = ERR_PTR(-ENXIO);
-        goto out;
-    }
+		state = ERR_PTR(-ENXIO);
+		goto out;
+	}
 
-    if (!state->port->iobase)
-    {
-        state->count--;
+	if(!state->port->iobase) {
+		state->count--;
 		up(&state->sem);
-        state = ERR_PTR(-ENXIO);
-        goto out;
-    }
+		state = ERR_PTR(-ENXIO);
+		goto out;
+	}
 
-    if (!state->info)
-    {
-        state->info = kmalloc(sizeof(struct ser_info), GFP_KERNEL);
+	if(!state->info) {
+		state->info = kmalloc(sizeof(struct ser_info), GFP_KERNEL);
 
-        if (state->info)
-        {
-            memset(state->info, 0, sizeof(struct ser_info));
-            init_waitqueue_head(&state->info->open_wait);
-            init_waitqueue_head(&state->info->delta_msr_wait);
+		if(state->info) {
+			memset(state->info, 0, sizeof(struct ser_info));
+			init_waitqueue_head(&state->info->open_wait);
+			init_waitqueue_head(&state->info->delta_msr_wait);
 
-            state->port->info = state->info;
+			state->port->info = state->info;
 
-            tasklet_init(&state->info->tlet, ser_tasklet_action, (unsigned long)state);
-        }
-        else
-        {
-            state->count--;
+			tasklet_init(&state->info->tlet, ser_tasklet_action, (unsigned long)state);
+		} else {
+			state->count--;
 			up(&state->sem);
-            state = ERR_PTR(-ENOMEM);
-        }
-    }
+			state = ERR_PTR(-ENOMEM);
+		}
+	}
 
 out:
 	up(&ser_port_sem);
-    return state;
+	return state;
 }
 
 
 static int
 ser_block_til_ready(
-					struct file *filp,
-					struct ser_state *state
-					)
+    struct file *filp,
+    struct ser_state *state
+)
 {
-    DECLARE_WAITQUEUE(wait, current);
-    struct ser_info *info = state->info;
-    struct ser_port *port = state->port;
+	DECLARE_WAITQUEUE(wait, current);
+	struct ser_info *info = state->info;
+	struct ser_port *port = state->port;
 
-    info->blocked_open++;
-    state->count--;
+	info->blocked_open++;
+	state->count--;
 
-    add_wait_queue(&info->open_wait, &wait);
+	add_wait_queue(&info->open_wait, &wait);
 
-    while (1)
-    {
-        set_current_state(TASK_INTERRUPTIBLE);
+	while(1) {
+		set_current_state(TASK_INTERRUPTIBLE);
 
-        if (tty_hung_up_p(filp) || info->tty == NULL)
-        {
-            break;
-        }
+		if(tty_hung_up_p(filp) || info->tty == NULL) {
+			break;
+		}
 
-        if (!(info->flags & WCH_UIF_INITIALIZED))
-        {
-            break;
-        }
+		if(!(info->flags & WCH_UIF_INITIALIZED)) {
+			break;
+		}
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-        if ((filp->f_flags & O_NONBLOCK) ||
-            (info->tty->termios->c_cflag & CLOCAL) ||
-            (info->tty->flags & (1 << TTY_IO_ERROR)))
+		if((filp->f_flags & O_NONBLOCK) ||
+		   (info->tty->termios->c_cflag & CLOCAL) ||
+		   (info->tty->flags & (1 << TTY_IO_ERROR)))
 #else
-        if ((filp->f_flags & O_NONBLOCK) ||
-            (info->tty->termios.c_cflag & CLOCAL) ||
-            (info->tty->flags & (1 << TTY_IO_ERROR)))
+		if((filp->f_flags & O_NONBLOCK) ||
+		   (info->tty->termios.c_cflag & CLOCAL) ||
+		   (info->tty->flags & (1 << TTY_IO_ERROR)))
 #endif
-        {
-            break;
-        }
+		{
+			break;
+		}
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-        if (info->tty->termios->c_cflag & CBAUD)
+		if(info->tty->termios->c_cflag & CBAUD)
 #else
-		if (info->tty->termios.c_cflag & CBAUD)
+		if(info->tty->termios.c_cflag & CBAUD)
 #endif
-        {
-            set_mctrl(port, TIOCM_DTR);
-        }
+		{
+			set_mctrl(port, TIOCM_DTR);
+		}
 
-        if (wch_ser_get_mctrl(port) & TIOCM_CAR)
-        {
-            break;
-        }
+		if(wch_ser_get_mctrl(port) & TIOCM_CAR) {
+			break;
+		}
 
 		up(&state->sem);
-        schedule();
+		schedule();
 		down(&state->sem);
 
-        if (signal_pending(current))
-        {
-            break;
-        }
-    }
+		if(signal_pending(current)) {
+			break;
+		}
+	}
 
-    set_current_state(TASK_RUNNING);
-    remove_wait_queue(&info->open_wait, &wait);
+	set_current_state(TASK_RUNNING);
+	remove_wait_queue(&info->open_wait, &wait);
 
-    state->count++;
-    info->blocked_open--;
+	state->count++;
+	info->blocked_open--;
 
-    if (signal_pending(current))
-    {
-        return -ERESTARTSYS;
-    }
+	if(signal_pending(current)) {
+		return -ERESTARTSYS;
+	}
 
-    if (!info->tty || tty_hung_up_p(filp))
-    {
-        return -EAGAIN;
-    }
+	if(!info->tty || tty_hung_up_p(filp)) {
+		return -EAGAIN;
+	}
 
-    return 0;
+	return 0;
 }
 
 
 static void
 ser_wait_until_sent(
-					struct tty_struct *tty,
-					int timeout
-					)
+    struct tty_struct *tty,
+    int timeout
+)
 {
-    struct ser_state *state = NULL;
-    struct ser_port *port = NULL;
-    unsigned long char_time;
-    unsigned long expire;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line >= wch_ser_port_total_cnt)
-    {
-        return;
-    }
+	struct ser_state *state = NULL;
+	struct ser_port *port = NULL;
+	unsigned long char_time;
+	unsigned long expire;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line >= wch_ser_port_total_cnt) {
+		return;
+	}
 
-    state = tty->driver_data;
-    port = state->port;
+	state = tty->driver_data;
+	port = state->port;
 
-    if (port->type == PORT_UNKNOWN || port->fifosize == 0)
-    {
-        return;
-    }
+	if(port->type == PORT_UNKNOWN || port->fifosize == 0) {
+		return;
+	}
 
-    char_time = (port->timeout - HZ/50) / port->fifosize;
+	char_time = (port->timeout - HZ / 50) / port->fifosize;
 
-    char_time = char_time / 5;
+	char_time = char_time / 5;
 
-    if (char_time == 0)
-    {
-        char_time = 1;
-    }
+	if(char_time == 0) {
+		char_time = 1;
+	}
 
-    if (timeout && timeout < char_time)
-    {
-        char_time = timeout;
-    }
+	if(timeout && timeout < char_time) {
+		char_time = timeout;
+	}
 
-    if (timeout == 0 || timeout > 2 * port->timeout)
-    {
-        timeout = 2 * port->timeout;
-    }
+	if(timeout == 0 || timeout > 2 * port->timeout) {
+		timeout = 2 * port->timeout;
+	}
 
-    expire = jiffies + timeout;
+	expire = jiffies + timeout;
 
-    while (!wch_ser_tx_empty(port))
-    {
-        set_current_state(TASK_INTERRUPTIBLE);
-        schedule_timeout(char_time);
+	while(!wch_ser_tx_empty(port)) {
+		set_current_state(TASK_INTERRUPTIBLE);
+		schedule_timeout(char_time);
 
-        if (signal_pending(current))
-        {
-            break;
-        }
+		if(signal_pending(current)) {
+			break;
+		}
 
-        if (time_after(jiffies, expire))
-        {
-            break;
-        }
-    }
-    set_current_state(TASK_RUNNING);
+		if(time_after(jiffies, expire)) {
+			break;
+		}
+	}
+	set_current_state(TASK_RUNNING);
 }
 
 static int
 ser_open(
-		 struct tty_struct *tty,
-		 struct file *filp
-		 )
+    struct tty_struct *tty,
+    struct file *filp
+)
 {
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    struct ser_driver *drv = (struct ser_driver *)tty->driver->driver_state;
+	struct ser_driver *drv = (struct ser_driver *)tty->driver->driver_state;
 #else
-    struct ser_driver *drv = (struct ser_driver *)tty->driver.driver_state;
+	struct ser_driver *drv = (struct ser_driver *)tty->driver.driver_state;
 #endif
-    struct ser_state *state;
-    int retval = 0;
+	struct ser_state *state;
+	int retval = 0;
 	int line = WCH_SER_DEVNUM(tty);
 
-    if (line < wch_ser_port_total_cnt)
-    {
-        retval = -ENODEV;
+	if(line < wch_ser_port_total_cnt) {
+		retval = -ENODEV;
 
-        if (line >= wch_ser_port_total_cnt)
-        {
-            goto fail;
-        }
-
-        state = ser_get(drv, line);
-        if (IS_ERR(state))
-        {
-            retval = PTR_ERR(state);
-            goto fail;
+		if(line >= wch_ser_port_total_cnt) {
+			goto fail;
 		}
 
-        if (!state)
-        {
-            goto fail;
-        }
+		state = ser_get(drv, line);
+		if(IS_ERR(state)) {
+			retval = PTR_ERR(state);
+			goto fail;
+		}
+
+		if(!state) {
+			goto fail;
+		}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 13))
-        tty->low_latency = (state->port->flags & WCH_UPF_LOW_LATENCY) ? 1 : 0;
-        tty->alt_speed = 0;
+		tty->low_latency = (state->port->flags & WCH_UPF_LOW_LATENCY) ? 1 : 0;
+		tty->alt_speed = 0;
 #else
 		state->port->state = state;
 		state->port0.low_latency = (state->port->flags & WCH_UPF_LOW_LATENCY) ? 1 : 0;
 #endif
-        tty->driver_data = state;
+		tty->driver_data = state;
 		state->info->tty = tty;
 
-        if (tty_hung_up_p(filp))
-        {
-            retval = -EAGAIN;
-            state->count--;
+		if(tty_hung_up_p(filp)) {
+			retval = -EAGAIN;
+			state->count--;
 			up(&state->sem);
-            goto fail;
-        }
+			goto fail;
+		}
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
 		tty_port_tty_set(&state->port0, tty);	//20140606 add
 #endif
-        retval = ser_startup(state, 0);
+		retval = ser_startup(state, 0);
 
-        if (retval == 0)
-        {
-            retval = ser_block_til_ready(filp, state);
-        }
+		if(retval == 0) {
+			retval = ser_block_til_ready(filp, state);
+		}
 
 		up(&state->sem);
 
-        if (retval == 0 && !(state->info->flags & WCH_UIF_NORMAL_ACTIVE))
-        {
-            state->info->flags |= WCH_UIF_NORMAL_ACTIVE;
+		if(retval == 0 && !(state->info->flags & WCH_UIF_NORMAL_ACTIVE)) {
+			state->info->flags |= WCH_UIF_NORMAL_ACTIVE;
 
-            ser_update_termios(state);
-        }
+			ser_update_termios(state);
+		}
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-        try_module_get(THIS_MODULE);
+		try_module_get(THIS_MODULE);
 #else
-        MOD_INC_USE_COUNT;
+		MOD_INC_USE_COUNT;
 #endif
 
-    }
+	}
 
 fail:
-    return retval;
+	return retval;
 }
 
 static void
 ser_close(
-		  struct tty_struct *tty,
-		  struct file *filp
-		  )
+    struct tty_struct *tty,
+    struct file *filp
+)
 {
-    struct ser_state *state = tty->driver_data;
-    struct ser_port *port;
-    int line = WCH_SER_DEVNUM(tty);
-    if (line < wch_ser_port_total_cnt)
-    {
-        if (!state || !state->port)
-        {
-            return;
-        }
+	struct ser_state *state = tty->driver_data;
+	struct ser_port *port;
+	int line = WCH_SER_DEVNUM(tty);
+	if(line < wch_ser_port_total_cnt) {
+		if(!state || !state->port) {
+			return;
+		}
 
-        port = state->port;
+		port = state->port;
 
-	down(&state->sem);
-        if (tty_hung_up_p(filp))
-        {
-            goto done;
-        }
+		down(&state->sem);
+		if(tty_hung_up_p(filp)) {
+			goto done;
+		}
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-        if ((tty->count == 1) && (state->count != 1))
-        {
-            printk("WCH Info : bad serial port count; tty->count is 1, state->count is %d\n", state->count);
-            state->count = 1;
-        }
+		if((tty->count == 1) && (state->count != 1)) {
+			printk("WCH Info : bad serial port count; tty->count is 1, state->count is %d\n", state->count);
+			state->count = 1;
+		}
 #endif
 
-        if (--state->count < 0)
-        {
-            printk("WCH Info : bad serial port count for ttyWCH%d: %d\n",port->line, state->count);
-            state->count = 0;
-        }
+		if(--state->count < 0) {
+			printk("WCH Info : bad serial port count for ttyWCH%d: %d\n", port->line, state->count);
+			state->count = 0;
+		}
 
-        if (state->count)
-        {
-            goto done;
-        }
+		if(state->count) {
+			goto done;
+		}
 
-        tty->closing = 1;
+		tty->closing = 1;
 
-        if (state->closing_wait != WCH_USF_CLOSING_WAIT_NONE)
-        {
-            tty_wait_until_sent(tty, state->closing_wait);
-        }
+		if(state->closing_wait != WCH_USF_CLOSING_WAIT_NONE) {
+			tty_wait_until_sent(tty, state->closing_wait);
+		}
 
-        if (state->info->flags & WCH_UIF_INITIALIZED)
-        {
-            unsigned long flags;
-            spin_lock_irqsave(&port->lock, flags);
-            wch_ser_stop_rx(port);
-            spin_unlock_irqrestore(&port->lock, flags);
+		if(state->info->flags & WCH_UIF_INITIALIZED) {
+			unsigned long flags;
+			spin_lock_irqsave(&port->lock, flags);
+			wch_ser_stop_rx(port);
+			spin_unlock_irqrestore(&port->lock, flags);
 
-            ser_wait_until_sent(tty, port->timeout);
-        }
+			ser_wait_until_sent(tty, port->timeout);
+		}
 
-        ser_shutdown(state);
-        ser_flush_buffer(tty);
+		ser_shutdown(state);
+		ser_flush_buffer(tty);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31))
 
-	tty_ldisc_flush(tty);
-/*        if (tty->ldisc->ops->flush_buffer)
-        {
-            tty->ldisc->ops->flush_buffer(tty);
-        }
-*/
+		tty_ldisc_flush(tty);
+		/*        if (tty->ldisc->ops->flush_buffer)
+		        {
+		            tty->ldisc->ops->flush_buffer(tty);
+		        }
+		*/
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27)&& LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,30) )
 		{
-			if (tty->ldisc.ops->flush_buffer)
-			{
+			if(tty->ldisc.ops->flush_buffer) {
 				tty->ldisc.ops->flush_buffer(tty);
 			}
 		}
 #else
 
-        if (tty->ldisc.flush_buffer)
-        {
-            tty->ldisc.flush_buffer(tty);
-        }
+		if(tty->ldisc.flush_buffer) {
+			tty->ldisc.flush_buffer(tty);
+		}
 
 #endif
 
-        tty->closing = 0;
-        if(state->info->tty)
-		 state->info->tty = NULL;
+		tty->closing = 0;
+		if(state->info->tty)
+			state->info->tty = NULL;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-	if(state->port0.tty)
-		tty_port_tty_set(&state->port0, NULL);	//20140606 add
+		if(state->port0.tty)
+			tty_port_tty_set(&state->port0, NULL);	//20140606 add
 #endif
-        if (state->info->blocked_open)
-        {
-            if (state->close_delay)
-            {
-                set_current_state(TASK_INTERRUPTIBLE);
-                schedule_timeout(state->close_delay);
-            }
-        }
+		if(state->info->blocked_open) {
+			if(state->close_delay) {
+				set_current_state(TASK_INTERRUPTIBLE);
+				schedule_timeout(state->close_delay);
+			}
+		}
 
-        state->info->flags &= ~WCH_UIF_NORMAL_ACTIVE;
-        wake_up_interruptible(&state->info->open_wait);
+		state->info->flags &= ~WCH_UIF_NORMAL_ACTIVE;
+		wake_up_interruptible(&state->info->open_wait);
 done:
 		up(&state->sem);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-        module_put(THIS_MODULE);
+		module_put(THIS_MODULE);
 #else
-        MOD_DEC_USE_COUNT;
+		MOD_DEC_USE_COUNT;
 #endif
 
-    }
+	}
 
 }
 
 
 static void
 wch_ser_set_mctrl(
-				  struct ser_port *port,
-				  unsigned int mctrl
-				  )
+    struct ser_port *port,
+    unsigned int mctrl
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    unsigned char mcr = 0;
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	unsigned char mcr = 0;
 
-	if (mctrl & TIOCM_RTS)
-    {
-        mcr |= UART_MCR_RTS;
-    }
+	if(mctrl & TIOCM_RTS) {
+		mcr |= UART_MCR_RTS;
+	}
 
-    if (mctrl & TIOCM_DTR)
-    {
-        mcr |= UART_MCR_DTR;
-    }
+	if(mctrl & TIOCM_DTR) {
+		mcr |= UART_MCR_DTR;
+	}
 
-    if (mctrl & TIOCM_OUT1)
-    {
-        mcr |= UART_MCR_OUT1;
-    }
+	if(mctrl & TIOCM_OUT1) {
+		mcr |= UART_MCR_OUT1;
+	}
 
-    if (mctrl & TIOCM_OUT2)
-    {
-        mcr |= UART_MCR_OUT2;
-    }
+	if(mctrl & TIOCM_OUT2) {
+		mcr |= UART_MCR_OUT2;
+	}
 
-    if (mctrl & TIOCM_LOOP)
-    {
-        mcr |= UART_MCR_LOOP;
-    }
+	if(mctrl & TIOCM_LOOP) {
+		mcr |= UART_MCR_LOOP;
+	}
 
-    mcr = (mcr & sp->mcr_mask) | sp->mcr_force | sp->mcr;
+	mcr = (mcr & sp->mcr_mask) | sp->mcr_force | sp->mcr;
 
-    WRITE_UART_MCR(sp, mcr);
+	WRITE_UART_MCR(sp, mcr);
 }
 
 
 static unsigned int
 wch_ser_tx_empty(
-				 struct ser_port *port
-				 )
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    unsigned long flags;
-    unsigned int ret;
-    spin_lock_irqsave(&sp->port.lock, flags);
-    ret = READ_UART_LSR(sp) & UART_LSR_TEMT ? TIOCSER_TEMT : 0;
-    spin_unlock_irqrestore(&sp->port.lock, flags);
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	unsigned long flags;
+	unsigned int ret;
+	spin_lock_irqsave(&sp->port.lock, flags);
+	ret = READ_UART_LSR(sp) & UART_LSR_TEMT ? TIOCSER_TEMT : 0;
+	spin_unlock_irqrestore(&sp->port.lock, flags);
 
-    return ret;
+	return ret;
 }
 
 
 static unsigned int
 wch_ser_get_mctrl(
-				  struct ser_port *port
-				  )
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    unsigned long flags;
-    unsigned char status;
-    unsigned int ret = 0;
-    spin_lock_irqsave(&sp->port.lock, flags);
-    status = READ_UART_MSR(sp);
-    spin_unlock_irqrestore(&sp->port.lock, flags);
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	unsigned long flags;
+	unsigned char status;
+	unsigned int ret = 0;
+	spin_lock_irqsave(&sp->port.lock, flags);
+	status = READ_UART_MSR(sp);
+	spin_unlock_irqrestore(&sp->port.lock, flags);
 
-    if (status & UART_MSR_DCD)
-    {
-        ret |= TIOCM_CAR;
-    }
+	if(status & UART_MSR_DCD) {
+		ret |= TIOCM_CAR;
+	}
 
-    if (status & UART_MSR_RI)
-    {
-        ret |= TIOCM_RNG;
-    }
+	if(status & UART_MSR_RI) {
+		ret |= TIOCM_RNG;
+	}
 
-    if (status & UART_MSR_DSR)
-    {
-        ret |= TIOCM_DSR;
-    }
+	if(status & UART_MSR_DSR) {
+		ret |= TIOCM_DSR;
+	}
 
-    if (status & UART_MSR_CTS)
-    {
-        ret |= TIOCM_CTS;
-    }
+	if(status & UART_MSR_CTS) {
+		ret |= TIOCM_CTS;
+	}
 
-    return ret;
+	return ret;
 }
 
 
 static void
 wch_ser_stop_tx(
-				struct ser_port *port,
-				unsigned int tty_stop
-				)
+    struct ser_port *port,
+    unsigned int tty_stop
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    if (sp->ier & UART_IER_THRI)
-    {
-        sp->ier &= ~UART_IER_THRI;
-        WRITE_UART_IER(sp, sp->ier);
-    }
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	if(sp->ier & UART_IER_THRI) {
+		sp->ier &= ~UART_IER_THRI;
+		WRITE_UART_IER(sp, sp->ier);
+	}
 }
 
 
 static void
 wch_ser_start_tx(
-				 struct ser_port *port,
-				 unsigned int tty_start
-				 )
+    struct ser_port *port,
+    unsigned int tty_start
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    if (!(sp->ier & UART_IER_THRI))
-    {
-        sp->ier |= UART_IER_THRI;
-        WRITE_UART_IER(sp, sp->ier);
-    }
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	if(!(sp->ier & UART_IER_THRI)) {
+		sp->ier |= UART_IER_THRI;
+		WRITE_UART_IER(sp, sp->ier);
+	}
 }
 
 
 static void
 wch_ser_stop_rx(
-				struct ser_port *port
-				)
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    sp->ier &= ~UART_IER_RLSI;
-    sp->port.read_status_mask &= ~UART_LSR_DR;
-    WRITE_UART_IER(sp, sp->ier);
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	sp->ier &= ~UART_IER_RLSI;
+	sp->port.read_status_mask &= ~UART_LSR_DR;
+	WRITE_UART_IER(sp, sp->ier);
 }
 
 
 static void
 wch_ser_enable_ms(
-				  struct ser_port *port
-				  )
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    sp->ier |= UART_IER_MSI;
-    WRITE_UART_IER(sp, sp->ier);
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	sp->ier |= UART_IER_MSI;
+	WRITE_UART_IER(sp, sp->ier);
 }
 
 
 static void
 wch_ser_break_ctl(
-				  struct ser_port *port,
-				  int break_state
-				  )
+    struct ser_port *port,
+    int break_state
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    unsigned long flags;
-    spin_lock_irqsave(&sp->port.lock, flags);
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	unsigned long flags;
+	spin_lock_irqsave(&sp->port.lock, flags);
 
-    if (break_state == -1)
-    {
-        sp->lcr |= UART_LCR_SBC;
-    }
-    else
-    {
-        sp->lcr &= ~UART_LCR_SBC;
-    }
+	if(break_state == -1) {
+		sp->lcr |= UART_LCR_SBC;
+	} else {
+		sp->lcr &= ~UART_LCR_SBC;
+	}
 
-    WRITE_UART_LCR(sp, sp->lcr);
-    spin_unlock_irqrestore(&sp->port.lock, flags);
+	WRITE_UART_LCR(sp, sp->lcr);
+	spin_unlock_irqrestore(&sp->port.lock, flags);
 }
 
 
 static int
 wch_ser_startup(
-				struct ser_port *port
-				)
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 
 	sp->capabilities = wch_uart_config[sp->port.type].flags;
-    sp->mcr = 0;
+	sp->mcr = 0;
 
-    if (sp->capabilities & UART_CLEAR_FIFO)
-    {
-        WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO);
-        WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO | UART_FCR_CLEAR_RCVR | UART_FCR_CLEAR_XMIT);
-        WRITE_UART_FCR(sp, 0);
-    }
+	if(sp->capabilities & UART_CLEAR_FIFO) {
+		WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO);
+		WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO | UART_FCR_CLEAR_RCVR | UART_FCR_CLEAR_XMIT);
+		WRITE_UART_FCR(sp, 0);
+	}
 
-    (void) READ_UART_LSR(sp);
-    (void) READ_UART_RX(sp);
-    (void) READ_UART_IIR(sp);
-    (void) READ_UART_MSR(sp);
+	(void) READ_UART_LSR(sp);
+	(void) READ_UART_RX(sp);
+	(void) READ_UART_IIR(sp);
+	(void) READ_UART_MSR(sp);
 
-    if (!(sp->port.flags & WCH_UPF_BUGGY_UART) && (READ_UART_LSR(sp) == 0xff))
-    {
-        printk("WCH Info : ttyWCH%d: LSR safety check engaged!\n", sp->port.line);
-        return -ENODEV;
-    }
+	if(!(sp->port.flags & WCH_UPF_BUGGY_UART) && (READ_UART_LSR(sp) == 0xff)) {
+		printk("WCH Info : ttyWCH%d: LSR safety check engaged!\n", sp->port.line);
+		return -ENODEV;
+	}
 
-    WRITE_UART_LCR(sp, UART_LCR_WLEN8);
+	WRITE_UART_LCR(sp, UART_LCR_WLEN8);
 
 	sp->ier = UART_IER_RLSI | UART_IER_RDI;
 
-    WRITE_UART_IER(sp, sp->ier);
+	WRITE_UART_IER(sp, sp->ier);
 
-    (void) READ_UART_LSR(sp);
-    (void) READ_UART_RX(sp);
-    (void) READ_UART_IIR(sp);
-    (void) READ_UART_MSR(sp);
-    return 0;
+	(void) READ_UART_LSR(sp);
+	(void) READ_UART_RX(sp);
+	(void) READ_UART_IIR(sp);
+	(void) READ_UART_MSR(sp);
+	return 0;
 }
 
 
 static void
 wch_ser_shutdown(
-				 struct ser_port *port
-				 )
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 
 	sp->ier = 0;
-    WRITE_UART_IER(sp, 0);
+	WRITE_UART_IER(sp, 0);
 
-    WRITE_UART_LCR(sp, READ_UART_LCR(sp) & ~UART_LCR_SBC);
+	WRITE_UART_LCR(sp, READ_UART_LCR(sp) & ~UART_LCR_SBC);
 
-    WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO | UART_FCR_CLEAR_RCVR | UART_FCR_CLEAR_XMIT);
-    WRITE_UART_FCR(sp, 0);
+	WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO | UART_FCR_CLEAR_RCVR | UART_FCR_CLEAR_XMIT);
+	WRITE_UART_FCR(sp, 0);
 
-    (void) READ_UART_RX(sp);
+	(void) READ_UART_RX(sp);
 }
 
 
 static unsigned int
 wch_ser_get_divisor(
-					struct ser_port *port,
-					unsigned int baud
-					)
+    struct ser_port *port,
+    unsigned int baud
+)
 {
-    unsigned int quot;
+	unsigned int quot;
 
-    if ((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 4))
-    {
-        quot = 0x8001;
-    }
-    else if ((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 8))
-    {
-        quot = 0x8002;
-    }
-    else
-    {
-        quot = ser_get_divisor(port, baud);
-    }
-    return quot;
+	if((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 4)) {
+		quot = 0x8001;
+	} else if((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 8)) {
+		quot = 0x8002;
+	} else {
+		quot = ser_get_divisor(port, baud);
+	}
+	return quot;
 }
 
 
 static void
 wch_ser_set_termios(
-					struct ser_port *port,
-					struct WCHTERMIOS *termios,
-					struct WCHTERMIOS *old
-					)
+    struct ser_port *port,
+    struct WCHTERMIOS *termios,
+    struct WCHTERMIOS *old
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    unsigned char cval;
-    unsigned char fcr = 0;
-    unsigned long flags;
-    unsigned int baud;
-    unsigned int quot;
-    switch (termios->c_cflag & CSIZE)
-    {
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	unsigned char cval;
+	unsigned char fcr = 0;
+	unsigned long flags;
+	unsigned int baud;
+	unsigned int quot;
+	switch(termios->c_cflag & CSIZE) {
 	case CS5:
 		cval = 0x00;
 		break;
@@ -2961,125 +2681,109 @@ wch_ser_set_termios(
 	case CS8:
 		cval = 0x03;
 		break;
-    }
+	}
 
-    if (termios->c_cflag & CSTOPB)
-    {
-        cval |= 0x04;
-    }
+	if(termios->c_cflag & CSTOPB) {
+		cval |= 0x04;
+	}
 
-    if (termios->c_cflag & PARENB)
-    {
-        cval |= UART_LCR_PARITY;
-    }
+	if(termios->c_cflag & PARENB) {
+		cval |= UART_LCR_PARITY;
+	}
 
-    if (!(termios->c_cflag & PARODD))
-    {
-        cval |= UART_LCR_EPAR;
-    }
+	if(!(termios->c_cflag & PARODD)) {
+		cval |= UART_LCR_EPAR;
+	}
 
 #ifdef CMSPAR
-    if (termios->c_cflag & CMSPAR)
-    {
-        cval |= UART_LCR_SPAR;
-    }
+	if(termios->c_cflag & CMSPAR) {
+		cval |= UART_LCR_SPAR;
+	}
 #endif
 
-    baud = ser_get_baud_rate(port, termios, old, 0, port->uartclk * 24 / 16);
+	/* uartclk is 1/12 cystal freq by default, so max = uartclk * 24 / 16 */
+	baud = ser_get_baud_rate(port, termios, old, 0, port->uartclk * 24 / 16);
 
-	/* add on 20210323 */
-	if (baud > 115200) {
+	quot = wch_ser_get_divisor(port, baud);
+	if(sp->capabilities & UART_USE_FIFO) {
+		if(baud < 2400) {
+			fcr = UART_FCR_ENABLE_FIFO | UART_FCR_TRIGGER_1;
+		} else {
+			fcr = UART_FCR_ENABLE_FIFO | UART_FCR_TRIGGER_14;
+		}
+	}
+
+	/* added on 20210323 */
+	if(baud > sp->port.baud_base) {
 		sp->ier |= 1 << 5;
-		baud /= 24;
 	} else {
 		sp->ier &= ~(1 << 5);
 	}
 
-	quot = wch_ser_get_divisor(port, baud);
-    if (sp->capabilities & UART_USE_FIFO)
-    {
-        if (baud < 2400)
-        {
-            fcr = UART_FCR_ENABLE_FIFO | UART_FCR_TRIGGER_1;
-        }
-        else
-        {
-			fcr = UART_FCR_ENABLE_FIFO | UART_FCR_TRIGGER_14;
-        }
-    }
-
 	sp->mcr &= ~UART_MCR_AFE;
 
-	if (termios->c_cflag & CRTSCTS)
-	{
+	if(termios->c_cflag & CRTSCTS) {
 		sp->mcr |= UART_MCR_AFE;
-        sp->mcr |= UART_MCR_RTS;
-    }
+		sp->mcr |= UART_MCR_RTS;
+	}
 
-	// Add On 20200928
+	/* added on 20200928 */
 	sp->mcr |= UART_MCR_OUT2;
 
-    spin_lock_irqsave(&sp->port.lock, flags);
+	spin_lock_irqsave(&sp->port.lock, flags);
 
-    ser_update_timeout(port, termios->c_cflag, baud);
+	ser_update_timeout(port, termios->c_cflag, baud);
 
 
-    sp->port.read_status_mask = UART_LSR_OE | UART_LSR_THRE | UART_LSR_DR;
+	sp->port.read_status_mask = UART_LSR_OE | UART_LSR_THRE | UART_LSR_DR;
 
-    if (termios->c_iflag & INPCK)
-    {
-        sp->port.read_status_mask |= UART_LSR_FE | UART_LSR_PE;
-    }
+	if(termios->c_iflag & INPCK) {
+		sp->port.read_status_mask |= UART_LSR_FE | UART_LSR_PE;
+	}
 
-    if (termios->c_iflag & (BRKINT | PARMRK))
-    {
-        sp->port.read_status_mask |= UART_LSR_BI;
-    }
+	if(termios->c_iflag & (BRKINT | PARMRK)) {
+		sp->port.read_status_mask |= UART_LSR_BI;
+	}
 
-    sp->port.ignore_status_mask = 0;
+	sp->port.ignore_status_mask = 0;
 
-    if (termios->c_iflag & IGNPAR)
-    {
-        sp->port.ignore_status_mask |= UART_LSR_PE | UART_LSR_FE;
-    }
+	if(termios->c_iflag & IGNPAR) {
+		sp->port.ignore_status_mask |= UART_LSR_PE | UART_LSR_FE;
+	}
 
-    if (termios->c_iflag & IGNBRK)
-    {
-        sp->port.ignore_status_mask |= UART_LSR_BI;
+	if(termios->c_iflag & IGNBRK) {
+		sp->port.ignore_status_mask |= UART_LSR_BI;
 
-        if (termios->c_iflag & IGNPAR)
-        {
-            sp->port.ignore_status_mask |= UART_LSR_OE;
-        }
-    }
+		if(termios->c_iflag & IGNPAR) {
+			sp->port.ignore_status_mask |= UART_LSR_OE;
+		}
+	}
 
-    if ((termios->c_cflag & CREAD) == 0)
-    {
-        sp->port.ignore_status_mask |= UART_LSR_DR;
-    }
+	if((termios->c_cflag & CREAD) == 0) {
+		sp->port.ignore_status_mask |= UART_LSR_DR;
+	}
 
-    sp->ier &= ~UART_IER_MSI;
-    if (WCH_ENABLE_MS(&sp->port, termios->c_cflag))
-    {
-        sp->ier |= UART_IER_MSI;
-    }
+	sp->ier &= ~UART_IER_MSI;
+	if(WCH_ENABLE_MS(&sp->port, termios->c_cflag)) {
+		sp->ier |= UART_IER_MSI;
+	}
 
-    WRITE_UART_LCR(sp, cval | UART_LCR_DLAB);
+	WRITE_UART_LCR(sp, cval | UART_LCR_DLAB);
 
-    WRITE_UART_DLL(sp, quot & 0xff);
-    WRITE_UART_DLM(sp, quot >> 8);
+	WRITE_UART_DLL(sp, quot & 0xff);
+	WRITE_UART_DLM(sp, quot >> 8);
 
-    WRITE_UART_FCR(sp, fcr);
+	WRITE_UART_FCR(sp, fcr);
 
-    WRITE_UART_LCR(sp, cval);
+	WRITE_UART_LCR(sp, cval);
 
-    sp->lcr = cval;
+	sp->lcr = cval;
 
-    wch_ser_set_mctrl(&sp->port, sp->port.mctrl);
+	wch_ser_set_mctrl(&sp->port, sp->port.mctrl);
 
-    WRITE_UART_IER(sp, sp->ier);
+	WRITE_UART_IER(sp, sp->ier);
 
-    spin_unlock_irqrestore(&sp->port.lock, flags);
+	spin_unlock_irqrestore(&sp->port.lock, flags);
 }
 
 
@@ -3093,464 +2797,417 @@ static void wch_ser_timeout(struct timer_list *t)
 {
 	struct wch_ser_port *sp = from_timer(sp, t, timer);
 #endif
-    unsigned int timeout;
-    unsigned int iir;
-    iir = READ_UART_IIR(sp);
+	unsigned int timeout;
+	unsigned int iir;
+	iir = READ_UART_IIR(sp);
 
-    if (!(iir & UART_IIR_NO_INT))
-    {
-        spin_lock(&sp->port.lock);
-        ser_handle_port(sp, iir);
-        spin_unlock(&sp->port.lock);
-    }
+	if(!(iir & UART_IIR_NO_INT)) {
+		spin_lock(&sp->port.lock);
+		ser_handle_port(sp, iir);
+		spin_unlock(&sp->port.lock);
+	}
 
-    timeout = sp->port.timeout;
-    timeout = timeout > 6 ? (timeout / 2 - 2) : 1;
+	timeout = sp->port.timeout;
+	timeout = timeout > 6 ? (timeout / 2 - 2) : 1;
 
-    mod_timer(&sp->timer, jiffies + timeout);
+	mod_timer(&sp->timer, jiffies + timeout);
 }
 
 
 static _INLINE_ void
 ser_receive_chars(
-				  struct wch_ser_port *sp,
-				  unsigned char *status
-				  )
+    struct wch_ser_port *sp,
+    unsigned char *status
+)
 {
-    struct tty_struct *tty = sp->port.info->tty;
-    unsigned char ch;
-    int max_count = 256;
-    unsigned char lsr = *status;
-    char flag;
+	struct tty_struct *tty = sp->port.info->tty;
+	unsigned char ch;
+	int max_count = 256;
+	unsigned char lsr = *status;
+	char flag;
 
-    do
-    {
-        ch = READ_UART_RX(sp);
-        flag = TTY_NORMAL;
-        sp->port.icount.rx++;
+	do {
+		ch = READ_UART_RX(sp);
+		flag = TTY_NORMAL;
+		sp->port.icount.rx++;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,4,18))
-        if (unlikely(lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE)))
+		if(unlikely(lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE)))
 #else
-        if (lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE))
+		if(lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE))
 #endif
-        {
-            if (lsr & UART_LSR_BI)
-            {
-                lsr &= ~(UART_LSR_FE | UART_LSR_PE);
-                sp->port.icount.brk++;
+		{
+			if(lsr & UART_LSR_BI) {
+				lsr &= ~(UART_LSR_FE | UART_LSR_PE);
+				sp->port.icount.brk++;
 
-                if (ser_handle_break(&sp->port))
-                {
-                    goto ignore_char;
-                }
-            }
-            else if (lsr & UART_LSR_PE)
-            {
-                sp->port.icount.parity++;
-            }
-            else if (lsr & UART_LSR_FE)
-            {
-                sp->port.icount.frame++;
-            }
+				if(ser_handle_break(&sp->port)) {
+					goto ignore_char;
+				}
+			} else if(lsr & UART_LSR_PE) {
+				sp->port.icount.parity++;
+			} else if(lsr & UART_LSR_FE) {
+				sp->port.icount.frame++;
+			}
 
-            if (lsr & UART_LSR_OE)
-            {
-                sp->port.icount.overrun++;
-            }
+			if(lsr & UART_LSR_OE) {
+				sp->port.icount.overrun++;
+			}
 
-            lsr &= sp->port.read_status_mask;
+			lsr &= sp->port.read_status_mask;
 
 
-            if (lsr & UART_LSR_BI)
-            {
-                flag = TTY_BREAK;
-            }
-            else if (lsr & UART_LSR_PE)
-            {
-                flag = TTY_PARITY;
-            }
-            else if (lsr & UART_LSR_FE)
-            {
-                flag = TTY_FRAME;
-            }
-        }
+			if(lsr & UART_LSR_BI) {
+				flag = TTY_BREAK;
+			} else if(lsr & UART_LSR_PE) {
+				flag = TTY_PARITY;
+			} else if(lsr & UART_LSR_FE) {
+				flag = TTY_FRAME;
+			}
+		}
 
 
-        if ((I_IXOFF(tty)) || I_IXON(tty))
-        {
-            if (ch == START_CHAR(tty))
-            {
-                tty->stopped = 0;
-                wch_ser_start_tx(&sp->port, 1);
-                goto ignore_char;
-            }
-            else if (ch == STOP_CHAR(tty))
-            {
-                tty->stopped = 1;
-                wch_ser_stop_tx(&sp->port, 1);
-                goto ignore_char;
-            }
-        }
+		if((I_IXOFF(tty)) || I_IXON(tty)) {
+			if(ch == START_CHAR(tty)) {
+				tty->stopped = 0;
+				wch_ser_start_tx(&sp->port, 1);
+				goto ignore_char;
+			} else if(ch == STOP_CHAR(tty)) {
+				tty->stopped = 1;
+				wch_ser_stop_tx(&sp->port, 1);
+				goto ignore_char;
+			}
+		}
 
-        ser_insert_char(&sp->port, lsr, UART_LSR_OE, ch, flag);
+		ser_insert_char(&sp->port, lsr, UART_LSR_OE, ch, flag);
 
 ignore_char:
-        lsr = READ_UART_LSR(sp);
+		lsr = READ_UART_LSR(sp);
 
-        if (lsr == 0xff)
-        {
-            lsr = 0x01;
-        }
+		if(lsr == 0xff) {
+			lsr = 0x01;
+		}
 
-    } while (lsr & (UART_LSR_DR | UART_LSR_BI) && (max_count-- > 0));
+	} while(lsr & (UART_LSR_DR | UART_LSR_BI) && (max_count-- > 0));
 
-    spin_unlock(&sp->port.lock);
+	spin_unlock(&sp->port.lock);
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 13))
-    tty_flip_buffer_push(tty);
+	tty_flip_buffer_push(tty);
 #else
-    tty_flip_buffer_push(&(sp->port.state->port0));
+	tty_flip_buffer_push(&(sp->port.state->port0));
 #endif
-    spin_lock(&sp->port.lock);
-    *status = lsr;
+	spin_lock(&sp->port.lock);
+	*status = lsr;
 }
 
 
 static _INLINE_ void
 ser_transmit_chars(
-				   struct wch_ser_port *sp
-				   )
+    struct wch_ser_port *sp
+)
 {
-    struct circ_buf *xmit = &sp->port.info->xmit;
-    int count;
+	struct circ_buf *xmit = &sp->port.info->xmit;
+	int count;
 
-    if ((!sp) || (!sp->port.iobase))
-    {
-        return;
-    }
+	if((!sp) || (!sp->port.iobase)) {
+		return;
+	}
 
-    if (!sp->port.info)
-    {
-        return;
-    }
+	if(!sp->port.info) {
+		return;
+	}
 
-    if (!xmit)
-    {
-        return;
-    }
+	if(!xmit) {
+		return;
+	}
 
-    if (sp->port.x_char)
-    {
-        WRITE_UART_TX(sp, sp->port.x_char);
-        sp->port.icount.tx++;
-        sp->port.x_char = 0;
-        return;
-    }
+	if(sp->port.x_char) {
+		WRITE_UART_TX(sp, sp->port.x_char);
+		sp->port.icount.tx++;
+		sp->port.x_char = 0;
+		return;
+	}
 
-    if (ser_circ_empty(xmit) || ser_tx_stopped(&sp->port))
-    {
-        wch_ser_stop_tx(&sp->port, 0);
-        return;
-    }
+	if(ser_circ_empty(xmit) || ser_tx_stopped(&sp->port)) {
+		wch_ser_stop_tx(&sp->port, 0);
+		return;
+	}
 
-    count = sp->port.fifosize;
+	count = sp->port.fifosize;
 
-    do
-    {
-        WRITE_UART_TX(sp, xmit->buf[xmit->tail]);
-        xmit->tail = (xmit->tail + 1) & (WCH_UART_XMIT_SIZE - 1);
-        sp->port.icount.tx++;
+	do {
+		WRITE_UART_TX(sp, xmit->buf[xmit->tail]);
+		xmit->tail = (xmit->tail + 1) & (WCH_UART_XMIT_SIZE - 1);
+		sp->port.icount.tx++;
 
-        if (ser_circ_empty(xmit))
-        {
-            break;
-        }
+		if(ser_circ_empty(xmit)) {
+			break;
+		}
 
-    } while (--count > 0);
+	} while(--count > 0);
 
-    if (ser_circ_chars_pending(xmit) < WAKEUP_CHARS)
-    {
-        ser_write_wakeup(&sp->port);
-    }
-/*
-    if (ser_circ_empty(xmit))
-    {
-        wch_ser_stop_tx(&sp->port, 0);
-    }
-*/
+	if(ser_circ_chars_pending(xmit) < WAKEUP_CHARS) {
+		ser_write_wakeup(&sp->port);
+	}
+	/*
+	    if (ser_circ_empty(xmit))
+	    {
+	        wch_ser_stop_tx(&sp->port, 0);
+	    }
+	*/
 }
 
 
 static _INLINE_ void
 ser_check_modem_status(
-					   struct wch_ser_port *sp,
-					   unsigned char status
-					   )
+    struct wch_ser_port *sp,
+    unsigned char status
+)
 {
-    if ((status & UART_MSR_ANY_DELTA) == 0)
-    {
-        return;
-    }
+	if((status & UART_MSR_ANY_DELTA) == 0) {
+		return;
+	}
 
-    if (!sp->port.info)
-    {
-        return;
-    }
+	if(!sp->port.info) {
+		return;
+	}
 
-    if (status & UART_MSR_TERI)
-    {
-        sp->port.icount.rng++;
-    }
+	if(status & UART_MSR_TERI) {
+		sp->port.icount.rng++;
+	}
 
-    if (status & UART_MSR_DDSR)
-    {
-        sp->port.icount.dsr++;
-    }
+	if(status & UART_MSR_DDSR) {
+		sp->port.icount.dsr++;
+	}
 
-    if (status & UART_MSR_DDCD)
-    {
-        ser_handle_dcd_change(&sp->port, status & UART_MSR_DCD);
-    }
+	if(status & UART_MSR_DDCD) {
+		ser_handle_dcd_change(&sp->port, status & UART_MSR_DCD);
+	}
 
-    if (status & UART_MSR_DCTS)
-    {
-        ser_handle_cts_change(&sp->port, status & UART_MSR_CTS);
-    }
+	if(status & UART_MSR_DCTS) {
+		ser_handle_cts_change(&sp->port, status & UART_MSR_CTS);
+	}
 
-    wake_up_interruptible(&sp->port.info->delta_msr_wait);
+	wake_up_interruptible(&sp->port.info->delta_msr_wait);
 }
 
 
 static _INLINE_ void
 ser_handle_port(
-				struct wch_ser_port *sp,
-				unsigned char iir
-				)
+    struct wch_ser_port *sp,
+    unsigned char iir
+)
 {
-    unsigned char lsr = READ_UART_LSR(sp);
-    unsigned char msr = 0;
+	unsigned char lsr = READ_UART_LSR(sp);
+	unsigned char msr = 0;
 
-    if (lsr == 0xff)
-    {
-        lsr = 0x01;
-    }
+	if(lsr == 0xff) {
+		lsr = 0x01;
+	}
 
-    if ((iir == UART_IIR_RLSI) || (iir == UART_IIR_CTO) || (iir == UART_IIR_RDI))
-    {
-        ser_receive_chars(sp, &lsr);
-    }
+	if((iir == UART_IIR_RLSI) || (iir == UART_IIR_CTO) || (iir == UART_IIR_RDI)) {
+		ser_receive_chars(sp, &lsr);
+	}
 
-    if ((iir == UART_IIR_THRI) && (lsr & UART_LSR_THRE))
-    {
-        ser_transmit_chars(sp);
-    }
+	if((iir == UART_IIR_THRI) && (lsr & UART_LSR_THRE)) {
+		ser_transmit_chars(sp);
+	}
 
-    msr = READ_UART_MSR(sp);
+	msr = READ_UART_MSR(sp);
 
-    if (msr & UART_MSR_ANY_DELTA)
-    {
-        ser_check_modem_status(sp, msr);
-    }
+	if(msr & UART_MSR_ANY_DELTA) {
+		ser_check_modem_status(sp, msr);
+	}
 }
 
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 static struct tty_operations wch_tty_ops = {
-    .open = ser_open,
-    .close = ser_close,
-    .write = ser_write,
-    .put_char = ser_put_char,
-    .flush_chars = ser_flush_chars,
-    .write_room = ser_write_room,
-    .chars_in_buffer = ser_chars_in_buffer,
-    .flush_buffer = ser_flush_buffer,
-    .ioctl = ser_ioctl,
-    .throttle = ser_throttle,
-    .unthrottle = ser_unthrottle,
-    .send_xchar = ser_send_xchar,
-    .set_termios = ser_set_termios,
-    .stop = ser_stop,
-    .start = ser_start,
-    .hangup = ser_hangup,
-    .break_ctl = ser_break_ctl,
-    .wait_until_sent = ser_wait_until_sent,
-    .tiocmget = ser_tiocmget,
-    .tiocmset = ser_tiocmset,
+	.open = ser_open,
+	.close = ser_close,
+	.write = ser_write,
+	.put_char = ser_put_char,
+	.flush_chars = ser_flush_chars,
+	.write_room = ser_write_room,
+	.chars_in_buffer = ser_chars_in_buffer,
+	.flush_buffer = ser_flush_buffer,
+	.ioctl = ser_ioctl,
+	.throttle = ser_throttle,
+	.unthrottle = ser_unthrottle,
+	.send_xchar = ser_send_xchar,
+	.set_termios = ser_set_termios,
+	.stop = ser_stop,
+	.start = ser_start,
+	.hangup = ser_hangup,
+	.break_ctl = ser_break_ctl,
+	.wait_until_sent = ser_wait_until_sent,
+	.tiocmget = ser_tiocmget,
+	.tiocmset = ser_tiocmset,
 };
 #endif
 
 extern int
 wch_ser_register_driver(
-						struct ser_driver *drv
-						)
+    struct ser_driver *drv
+)
 {
-    struct tty_driver *normal = NULL;
-    int i;
-    int ret = 0;
+	struct tty_driver *normal = NULL;
+	int i;
+	int ret = 0;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
 	drv->nr = wch_ser_port_total_cnt;
-    drv->state = kmalloc(sizeof(struct ser_state) * drv->nr, GFP_KERNEL);
-    ret = -ENOMEM;
+	drv->state = kmalloc(sizeof(struct ser_state) * drv->nr, GFP_KERNEL);
+	ret = -ENOMEM;
 
-    if (!drv->state)
-    {
-        printk("WCH Error: Allocate memory fail !\n\n");
-        goto out;
-    }
+	if(!drv->state) {
+		printk("WCH Error: Allocate memory fail !\n\n");
+		goto out;
+	}
 
-    memset(drv->state, 0, sizeof(struct ser_state) * drv->nr);
+	memset(drv->state, 0, sizeof(struct ser_state) * drv->nr);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    normal = alloc_tty_driver(drv->nr);
+	normal = alloc_tty_driver(drv->nr);
 #else
-    normal = &drv->tty_driver;
+	normal = &drv->tty_driver;
 #endif
-    if (!normal)
-    {
-        printk("WCH Error: Allocate tty driver fail !\n\n");
-        goto out;
-    }
+	if(!normal) {
+		printk("WCH Error: Allocate tty driver fail !\n\n");
+		goto out;
+	}
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    drv->tty_driver = normal;
+	drv->tty_driver = normal;
 #endif
-    normal->magic = TTY_DRIVER_MAGIC;
-    normal->name = drv->dev_name;
-    normal->major = drv->major;
-    normal->minor_start = drv->minor;
-    normal->num = wch_ser_port_total_cnt;
-    normal->type = TTY_DRIVER_TYPE_SERIAL;
-    normal->subtype = SERIAL_TYPE_NORMAL;
-    normal->flags = TTY_DRIVER_REAL_RAW;
-    normal->init_termios = tty_std_termios;
-    normal->init_termios.c_cflag = B9600 | CS8 | CREAD | HUPCL | CLOCAL;
-    normal->init_termios.c_iflag = 0;
+	normal->magic = TTY_DRIVER_MAGIC;
+	normal->name = drv->dev_name;
+	normal->major = drv->major;
+	normal->minor_start = drv->minor;
+	normal->num = wch_ser_port_total_cnt;
+	normal->type = TTY_DRIVER_TYPE_SERIAL;
+	normal->subtype = SERIAL_TYPE_NORMAL;
+	normal->flags = TTY_DRIVER_REAL_RAW;
+	normal->init_termios = tty_std_termios;
+	normal->init_termios.c_cflag = B9600 | CS8 | CREAD | HUPCL | CLOCAL;
+	normal->init_termios.c_iflag = 0;
 
-    normal->driver_state = drv;
+	normal->driver_state = drv;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    tty_set_operations(normal, &wch_tty_ops);
+	tty_set_operations(normal, &wch_tty_ops);
 #else
-    normal->refcount = &ser_refcount;
-    normal->table = ser_tty;
-    normal->termios = ser_termios;
-    normal->termios_locked = ser_termios_locked;
+	normal->refcount = &ser_refcount;
+	normal->table = ser_tty;
+	normal->termios = ser_termios;
+	normal->termios_locked = ser_termios_locked;
 
-    normal->open = ser_open;
-    normal->close = ser_close;
-    normal->write = ser_write;
-    normal->put_char = ser_put_char;
-    normal->flush_chars = ser_flush_chars;
-    normal->write_room = ser_write_room;
-    normal->chars_in_buffer = ser_chars_in_buffer;
-    normal->flush_buffer = ser_flush_buffer;
-    normal->ioctl = ser_ioctl;
-    normal->throttle = ser_throttle;
-    normal->unthrottle = ser_unthrottle;
-    normal->send_xchar = ser_send_xchar;
-    normal->set_termios = ser_set_termios;
-    normal->stop = ser_stop;
-    normal->start = ser_start;
-    normal->hangup = ser_hangup;
-    normal->break_ctl = ser_break_ctl;
-    normal->wait_until_sent = ser_wait_until_sent;
+	normal->open = ser_open;
+	normal->close = ser_close;
+	normal->write = ser_write;
+	normal->put_char = ser_put_char;
+	normal->flush_chars = ser_flush_chars;
+	normal->write_room = ser_write_room;
+	normal->chars_in_buffer = ser_chars_in_buffer;
+	normal->flush_buffer = ser_flush_buffer;
+	normal->ioctl = ser_ioctl;
+	normal->throttle = ser_throttle;
+	normal->unthrottle = ser_unthrottle;
+	normal->send_xchar = ser_send_xchar;
+	normal->set_termios = ser_set_termios;
+	normal->stop = ser_stop;
+	normal->start = ser_start;
+	normal->hangup = ser_hangup;
+	normal->break_ctl = ser_break_ctl;
+	normal->wait_until_sent = ser_wait_until_sent;
 #endif
 
-    for (i = 0; i < drv->nr; i++)
-    {
-        struct ser_state *state = drv->state + i;
-        if (!state)
-        {
-            ret = -1;
-            printk("WCH Error: Memory error !\n\n");
-            goto out;
-        }
+	for(i = 0; i < drv->nr; i++) {
+		struct ser_state *state = drv->state + i;
+		if(!state) {
+			ret = -1;
+			printk("WCH Error: Memory error !\n\n");
+			goto out;
+		}
 
-        state->close_delay = 5 * HZ / 100;
-        state->closing_wait = 3 * HZ;
+		state->close_delay = 5 * HZ / 100;
+		state->closing_wait = 3 * HZ;
 
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-	tty_port_init(&state->port0);
+		tty_port_init(&state->port0);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
-		sema_init(&state->sem,1);
+		sema_init(&state->sem, 1);
 #else
 		init_MUTEX(&state->sem);
 #endif
-    }
+	}
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,28))
 	kref_init(&normal->kref);
 #endif
-    ret = tty_register_driver(normal);
-    if (ret < 0)
-    {
-        printk("WCH Error: Register tty driver fail !\n\n");
-        goto out;
-    }
+	ret = tty_register_driver(normal);
+	if(ret < 0) {
+		printk("WCH Error: Register tty driver fail !\n\n");
+		goto out;
+	}
 
 out:
-    if (ret < 0)
-    {
+	if(ret < 0) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-        put_tty_driver(normal);
+		put_tty_driver(normal);
 #endif
-        kfree(drv->state);
-    }
+		kfree(drv->state);
+	}
 
-    return (ret);
+	return (ret);
 }
 
 
 extern void
 wch_ser_unregister_driver(
-						  struct ser_driver *drv
-						  )
+    struct ser_driver *drv
+)
 {
-    struct tty_driver *normal;
+	struct tty_driver *normal;
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-    normal = drv->tty_driver;
-    if (!normal)
-    {
-        return;
-    }
+	normal = drv->tty_driver;
+	if(!normal) {
+		return;
+	}
 
-    tty_unregister_driver(normal);
-    put_tty_driver(normal);
-    drv->tty_driver = NULL;
+	tty_unregister_driver(normal);
+	put_tty_driver(normal);
+	drv->tty_driver = NULL;
 
 #else
-    normal = &drv->tty_driver;
-    if (!normal)
-    {
-        return;
-    }
+	normal = &drv->tty_driver;
+	if(!normal) {
+		return;
+	}
 
-    tty_unregister_driver(normal);
+	tty_unregister_driver(normal);
 #endif
-    if(drv->state)
-    {
-    	kfree(drv->state);
-    }
+	if(drv->state) {
+		kfree(drv->state);
+	}
 }
 
 
 static void
 wch_ser_request_io(
-				   struct ser_port *port
-				   )
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
-    switch (sp->port.iotype)
-    {
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	switch(sp->port.iotype) {
 	case WCH_UPIO_PORT:
 		request_region(sp->port.iobase, WCH_SER_ADDRESS_LENGTH, "wch_ser");
 		break;
@@ -3558,137 +3215,129 @@ wch_ser_request_io(
 		break;
 	default:
 		break;
-    }
+	}
 }
 
 
 static void
 wch_ser_configure_port(
-					   struct ser_driver *drv,
-					   struct ser_state *state,
-					   struct ser_port *port
-					   )
+    struct ser_driver *drv,
+    struct ser_state *state,
+    struct ser_port *port
+)
 {
-    unsigned long flags;
-    if (!port->iobase)
-    {
-        return;
-    }
+	unsigned long flags;
+	if(!port->iobase) {
+		return;
+	}
 
-    flags = WCH_UART_CONFIG_TYPE;
+	flags = WCH_UART_CONFIG_TYPE;
 
-    if (port->type != PORT_UNKNOWN)
-    {
-        wch_ser_request_io(port);
+	if(port->type != PORT_UNKNOWN) {
+		wch_ser_request_io(port);
 
-        spin_lock_irqsave(&port->lock, flags);
+		spin_lock_irqsave(&port->lock, flags);
 
-        wch_ser_set_mctrl(port, 0);
-        spin_unlock_irqrestore(&port->lock, flags);
-    }
+		wch_ser_set_mctrl(port, 0);
+		spin_unlock_irqrestore(&port->lock, flags);
+	}
 }
 
 
 static int
 wch_ser_add_one_port(
-					 struct ser_driver *drv,
-					 struct ser_port *port
-					 )
+    struct ser_driver *drv,
+    struct ser_port *port
+)
 {
-    struct ser_state *state = NULL;
+	struct ser_state *state = NULL;
 
-    int ret = 0;
+	int ret = 0;
 
-    if (port->line >= drv->nr)
-    {
-        return -EINVAL;
-    }
+	if(port->line >= drv->nr) {
+		return -EINVAL;
+	}
 
-    state = drv->state + port->line;
+	state = drv->state + port->line;
 
 	down(&ser_port_sem);
 
-    if (state->port)
-    {
-        ret = -EINVAL;
-        goto out;
-    }
+	if(state->port) {
+		ret = -EINVAL;
+		goto out;
+	}
 
-    state->port = port;
+	state->port = port;
 
-    port->info = state->info;
+	port->info = state->info;
 //    port->state = state;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-    drv->tty_driver->ports[port->line] = &state->port0;
+	drv->tty_driver->ports[port->line] = &state->port0;
 #endif
-    wch_ser_configure_port(drv, state, port);
+	wch_ser_configure_port(drv, state, port);
 
 out:
 	up(&ser_port_sem);
-    return ret;
+	return ret;
 }
 
 
 extern int
 wch_ser_register_ports(
-					   struct ser_driver *drv
-					   )
+    struct ser_driver *drv
+)
 {
-    int i;
-    int ret;
+	int i;
+	int ret;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
-    for (i = 0; i < wch_ser_port_total_cnt; i++)
-    {
-        struct wch_ser_port *sp = &wch_ser_table[i];
+	for(i = 0; i < wch_ser_port_total_cnt; i++) {
+		struct wch_ser_port *sp = &wch_ser_table[i];
 
-        if (!sp)
-        {
-            return -1;
-        }
+		if(!sp) {
+			return -1;
+		}
 
-        sp->port.line = i;
+		sp->port.line = i;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-        if (sp->port.iobase)
+		if(sp->port.iobase)
 #endif
-        {
+		{
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0))
-            init_timer(&sp->timer);
-            sp->timer.function = wch_ser_timeout;
+			init_timer(&sp->timer);
+			sp->timer.function = wch_ser_timeout;
 #else
-	    	timer_setup(&sp->timer, wch_ser_timeout, 0);
+			timer_setup(&sp->timer, wch_ser_timeout, 0);
 #endif
 
-            sp->mcr_mask = ~0;
-            sp->mcr_force = 0;
+			sp->mcr_mask = ~0;
+			sp->mcr_force = 0;
 
-            ret = wch_ser_add_one_port(drv, &sp->port);
+			ret = wch_ser_add_one_port(drv, &sp->port);
 
-            if (ret != 0)
-            {
-                return ret;
-            }
-        }
-        printk("Setup ttyWCH%d - PCIe port: port %x, irq %d, type %d\n",
-			sp->port.line, sp->port.iobase, sp->port.irq, sp->port.iotype);
-    }
+			if(ret != 0) {
+				return ret;
+			}
+		}
+		printk("Setup ttyWCH%d - PCIe port: port %x, irq %d, type %d\n",
+		       sp->port.line, sp->port.iobase, sp->port.irq, sp->port.iotype);
+	}
 
-    return 0;
+	return 0;
 }
 
 
 static void
 wch_ser_release_io(
-				   struct ser_port *port
-				   )
+    struct ser_port *port
+)
 {
-    struct wch_ser_port *sp = (struct wch_ser_port *)port;
+	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 
-    switch (sp->port.iotype)
-    {
+	switch(sp->port.iotype) {
 	case WCH_UPIO_PORT:
 		release_region(sp->port.iobase, WCH_SER_ADDRESS_LENGTH);
 		break;
@@ -3696,39 +3345,36 @@ wch_ser_release_io(
 		break;
 	default:
 		break;
-    }
+	}
 }
 
 
 static void
 wch_ser_unconfigure_port(
-						 struct ser_driver *drv,
-						 struct ser_state *state
-						 )
+    struct ser_driver *drv,
+    struct ser_state *state
+)
 {
-    struct ser_port *port = state->port;
-    struct ser_info *info = state->info;
-    if (info && info->tty)
-    {
-        tty_hangup(info->tty);
-    }
+	struct ser_port *port = state->port;
+	struct ser_info *info = state->info;
+	if(info && info->tty) {
+		tty_hangup(info->tty);
+	}
 
 	down(&state->sem);
 
-    state->info = NULL;
+	state->info = NULL;
 
-    if (port->type != PORT_UNKNOWN)
-    {
-        wch_ser_release_io(port);
-    }
+	if(port->type != PORT_UNKNOWN) {
+		wch_ser_release_io(port);
+	}
 
-    port->type = PORT_UNKNOWN;
+	port->type = PORT_UNKNOWN;
 
-    if (info)
-    {
-        tasklet_kill(&info->tlet);
-        kfree(info);
-    }
+	if(info) {
+		tasklet_kill(&info->tlet);
+		kfree(info);
+	}
 
 	up(&state->sem);
 }
@@ -3736,122 +3382,104 @@ wch_ser_unconfigure_port(
 
 static int
 wch_ser_remove_one_port(
-						struct ser_driver *drv,
-						struct ser_port *port
-						)
+    struct ser_driver *drv,
+    struct ser_port *port
+)
 {
-    struct ser_state *state = drv->state + port->line;
+	struct ser_state *state = drv->state + port->line;
 
-    if (state->port != port)
-    {
-        printk("WCH Info : Removing wrong port: %p != %p\n\n",state->port, port);
-    }
+	if(state->port != port) {
+		printk("WCH Info : Removing wrong port: %p != %p\n\n", state->port, port);
+	}
 
 	down(&ser_port_sem);
 
-    wch_ser_unconfigure_port(drv, state);
+	wch_ser_unconfigure_port(drv, state);
 
-    state->port = NULL;
+	state->port = NULL;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-    drv->tty_driver->ports[port->line] = NULL;
+	drv->tty_driver->ports[port->line] = NULL;
 #endif
 	up(&ser_port_sem);
-    return 0;
+	return 0;
 }
 
 
 extern
 void
 wch_ser_unregister_ports(
-	struct ser_driver *drv
-	)
+    struct ser_driver *drv
+)
 {
-    int i;
+	int i;
 
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-    for (i = 0; i < wch_ser_port_total_cnt; i++)
-    {
-        struct wch_ser_port *sp = &wch_ser_table[i];
+	for(i = 0; i < wch_ser_port_total_cnt; i++) {
+		struct wch_ser_port *sp = &wch_ser_table[i];
 
-        if (sp->port.iobase)
-        {
-            wch_ser_remove_one_port(drv, &sp->port);
-        }
-    }
+		if(sp->port.iobase) {
+			wch_ser_remove_one_port(drv, &sp->port);
+		}
+	}
 }
 
 extern
 int
 wch_ser_interrupt(
-	struct wch_board *sb,
-	struct wch_ser_port *first_sp
-	)
+    struct wch_board *sb,
+    struct wch_ser_port *first_sp
+)
 {
-    struct wch_ser_port *sp;// = NULL;
-    int i;
-    int max;
+	struct wch_ser_port *sp;
+	int i;
+	int max;
 	unsigned long irqbits;
-    unsigned char ch438irqbits;
-    unsigned long bits;
-    int pass_counter = 0;
-    unsigned char iir;
+	unsigned char ch438irqbits;
+	unsigned long bits;
+	int pass_counter = 0;
+	unsigned char iir;
 
-    max = sb->ser_ports;
+	max = sb->ser_ports;
 
-    if ((first_sp->port.port_flag & PORTFLAG_REMAP) == PORTFLAG_REMAP) // CH352_2S CH352_1S1P
-    {
-        while (1)
-        {
-            for (i = 0; i < max; i++)
-            {
-                sp = first_sp + i;
+	if((first_sp->port.port_flag & PORTFLAG_REMAP) == PORTFLAG_REMAP) { // CH352_2S CH352_1S1P
+		while(1) {
+			for(i = 0; i < max; i++) {
+				sp = first_sp + i;
 
-                if (!sp->port.iobase)
-                {
-                    continue;
-                }
+				if(!sp->port.iobase) {
+					continue;
+				}
 
-                iir = READ_UART_IIR(sp) & 0x0f;
+				iir = READ_UART_IIR(sp) & 0x0f;
 
-                if (iir & UART_IIR_NO_INT)
-                {
-                    continue;
-                }
-                else
-                {
-                    spin_lock(&sp->port.lock);
-                    ser_handle_port(sp, iir);
-                    spin_unlock(&sp->port.lock);
-                }
-            }
+				if(iir & UART_IIR_NO_INT) {
+					continue;
+				} else {
+					spin_lock(&sp->port.lock);
+					ser_handle_port(sp, iir);
+					spin_unlock(&sp->port.lock);
+				}
+			}
 
-            if (pass_counter++ > INTERRUPT_COUNT)
-            {
-                break;
-            }
-        }
-    }
-	else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH353_4S)) // CH353_4S
-	{
-		while (1)
-		{
+			if(pass_counter++ > INTERRUPT_COUNT) {
+				break;
+			}
+		}
+	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH353_4S)) { // CH353_4S
+		while(1) {
 			irqbits = READ_INTERRUPT_VECTOR_BYTE(first_sp) & first_sp->port.vector_mask;
-			if (irqbits == 0x0000)
-			{
+			if(irqbits == 0x0000) {
 				break;
 			}
 
-			for (i = 0, bits = 1; i < max; i++, bits <<= 1)
-			{
-				if(i == 0x02)
-				{
+			for(i = 0, bits = 1; i < max; i++, bits <<= 1) {
+				if(i == 0x02) {
 					bits <<= 2;
 				}
-				if (!(bits & irqbits))
-				{
+				if(!(bits & irqbits)) {
 					continue;
 				}
 
@@ -3859,38 +3487,28 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
 
-			if (pass_counter++ > INTERRUPT_COUNT)
-			{
+			if(pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	}
-	else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH359_16S)) // CH359_16S
-	{
-		while (1)
-		{
+	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH359_16S)) { // CH359_16S
+		while(1) {
 			irqbits = READ_INTERRUPT_VECTOR_WORD(first_sp) & first_sp->port.vector_mask;
-			if (irqbits == 0x0000)
-			{
+			if(irqbits == 0x0000) {
 				break;
 			}
 
-			for (i = 0, bits = 1; i < max; i++, bits <<= 1)
-			{
-				if (!(bits & irqbits))
-				{
+			for(i = 0, bits = 1; i < max; i++, bits <<= 1) {
+				if(!(bits & irqbits)) {
 					continue;
 				}
 
@@ -3898,58 +3516,46 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
 
-			if (pass_counter++ > INTERRUPT_COUNT)
-			{
+			if(pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	}
-	else if ((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) ||
-		(first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_8S)) // CH384_8S CH384_28S
-	{
-		while (1)
-		{
+	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) ||
+	          (first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_8S)) { // CH384_8S CH384_28S
+		while(1) {
 			irqbits = READ_INTERRUPT_VECTOR_DWORD(first_sp) & first_sp->port.vector_mask;
 
-			if ((irqbits & 0x80000000) != 0 &&
-				(irqbits & 0x40000000) != 0 &&
-				(irqbits & 0x20000000) != 0 &&
-				(irqbits & 0x00000100) == 0 &&
-				(irqbits & 0x00000200) == 0 &&
-				(irqbits & 0x00000400) == 0 &&
-				(irqbits & 0x00000800) == 0)
-			{
+			if((irqbits & 0x80000000) != 0 &&
+			   (irqbits & 0x40000000) != 0 &&
+			   (irqbits & 0x20000000) != 0 &&
+			   (irqbits & 0x00000100) == 0 &&
+			   (irqbits & 0x00000200) == 0 &&
+			   (irqbits & 0x00000400) == 0 &&
+			   (irqbits & 0x00000800) == 0) {
 				break;
 			}
 
-			// handle port 21~28
-			if ((irqbits & 0x80000000) == 0)
-			{
+			/* handle CH438 #3 */
+			if((irqbits & 0x80000000) == 0) {
 				sp = first_sp + 0x14;
 				ch438irqbits = READ_INTERRUPT_VECTOR_BYTE(sp) & sp->port.vector_mask;
-				if (ch438irqbits != 0) {
-					for (i = 0; i < 0x08; i++) {
-						if (ch438irqbits & (1 << i)) {
+				if(ch438irqbits != 0) {
+					for(i = 0; i < 0x08; i++) {
+						if(ch438irqbits & (1 << i)) {
 							sp += i;
 							iir = READ_UART_IIR(sp) & 0x0f;
-							if (iir & UART_IIR_NO_INT)
-							{
+							if(iir & UART_IIR_NO_INT) {
 								continue;
-							}
-							else
-							{
+							} else {
 								spin_lock(&sp->port.lock);
 								ser_handle_port(sp, iir);
 								spin_unlock(&sp->port.lock);
@@ -3958,21 +3564,18 @@ wch_ser_interrupt(
 					}
 				}
 			}
-			if ((irqbits & 0x40000000) == 0)
-			{
+			/* handle CH438 #2 */
+			if((irqbits & 0x40000000) == 0) {
 				sp = first_sp + 0x0C;
 				ch438irqbits = READ_INTERRUPT_VECTOR_BYTE(sp) & sp->port.vector_mask;
-				if (ch438irqbits != 0) {
-					for (i = 0; i < 0x08; i++) {
-						if (ch438irqbits & (1 << i)) {
+				if(ch438irqbits != 0) {
+					for(i = 0; i < 0x08; i++) {
+						if(ch438irqbits & (1 << i)) {
 							sp += i;
 							iir = READ_UART_IIR(sp) & 0x0f;
-							if (iir & UART_IIR_NO_INT)
-							{
+							if(iir & UART_IIR_NO_INT) {
 								continue;
-							}
-							else
-							{
+							} else {
 								spin_lock(&sp->port.lock);
 								ser_handle_port(sp, iir);
 								spin_unlock(&sp->port.lock);
@@ -3981,28 +3584,24 @@ wch_ser_interrupt(
 					}
 				}
 			}
-			if ((irqbits & 0x20000000) == 0)
-			{
-				if (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) // CH384_28S
-				{
+			/* handle CH438 #1 */
+			if((irqbits & 0x20000000) == 0) {
+				/* CH384_28S */
+				if(first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) {
 					sp = first_sp + 0x04;
-				}
-				else // CH384_8S
-				{
+				} else {
+					/* CH384_8S */
 					sp = first_sp;
 				}
 				ch438irqbits = READ_INTERRUPT_VECTOR_BYTE(sp) & sp->port.vector_mask;
-				if (ch438irqbits != 0) {
-					for (i = 0; i < 0x08; i++) {
-						if (ch438irqbits & (1 << i)) {
+				if(ch438irqbits != 0) {
+					for(i = 0; i < 0x08; i++) {
+						if(ch438irqbits & (1 << i)) {
 							sp += i;
 							iir = READ_UART_IIR(sp) & 0x0f;
-							if (iir & UART_IIR_NO_INT)
-							{
+							if(iir & UART_IIR_NO_INT) {
 								continue;
-							}
-							else
-							{
+							} else {
 								spin_lock(&sp->port.lock);
 								ser_handle_port(sp, iir);
 								spin_unlock(&sp->port.lock);
@@ -4011,250 +3610,180 @@ wch_ser_interrupt(
 					}
 				}
 			}
-			if ((irqbits & 0x00000100) == 0x00000100)
-			{
+			if((irqbits & 0x00000100) == 0x00000100) {
 				sp = first_sp;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
-			if ((irqbits & 0x00000200) == 0x00000200)
-			{
+			if((irqbits & 0x00000200) == 0x00000200) {
 				sp = first_sp + 0x01;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
-			if ((irqbits & 0x00000400) == 0x00000400)
-			{
+			if((irqbits & 0x00000400) == 0x00000400) {
 				sp = first_sp + 0x02;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
-			if ((irqbits & 0x00000800) == 0x00000800)
-			{
+			if((irqbits & 0x00000800) == 0x00000800) {
 				sp = first_sp + 0x03;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
 
-			if (pass_counter++ > INTERRUPT_COUNT)
-			{
+			if(pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	}
-	else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH365_32S))
-	{
-		while (1)
-		{
-			if((inb(first_sp->port.chip_iobase + 0xF8) & 0x04) != 0x04)
-			{
+	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH365_32S)) {
+		while(1) {
+			if((inb(first_sp->port.chip_iobase + 0xF8) & 0x04) != 0x04) {
 				break;
 			}
 
 			irqbits = inb(first_sp->port.chip_iobase) & first_sp->port.vector_mask;
-			if (irqbits == 0xFF)
-			{
+			if(irqbits == 0xFF) {
 				break;
 			}
 
-			if ((irqbits & 0x00000010) == 0) // first ch438 irq
-			{
-				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1)
-				{
+			if((irqbits & 0x00000010) == 0) { // first ch438 irq
+				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i;
 					ch438irqbits = readb(sp->port.board_membase + 0x100 + 0x4F) & sp->port.vector_mask;
-					if (ch438irqbits == 0x00000000)
-					{
+					if(ch438irqbits == 0x00000000) {
 						break;
 					}
-					if (!(bits & ch438irqbits))
-					{
+					if(!(bits & ch438irqbits)) {
 						continue;
-					}
-					else
-					{
+					} else {
 						break;
 					}
 				}
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			}
-			else if ((irqbits & 0x00000020) == 0)
-			{
-				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1)
-				{
+			} else if((irqbits & 0x00000020) == 0) {
+				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i + 0x08;
 					ch438irqbits = readb(sp->port.board_membase + 0x180 + 0x4F) & sp->port.vector_mask;
-					if (ch438irqbits == 0x00000000)
-					{
+					if(ch438irqbits == 0x00000000) {
 						break;
 					}
-					if (!(bits & ch438irqbits))
-					{
+					if(!(bits & ch438irqbits)) {
 						continue;
-					}
-					else
-					{
+					} else {
 						break;
 					}
 				}
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			}
-			else if ((irqbits & 0x00000040) == 0)
-			{
-				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1)
-				{
+			} else if((irqbits & 0x00000040) == 0) {
+				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i + 0x10;
 					ch438irqbits = readb(sp->port.board_membase + 0x200 + 0x4F) & sp->port.vector_mask;
-					if (ch438irqbits == 0x00000000)
-					{
+					if(ch438irqbits == 0x00000000) {
 						break;
 					}
-					if (!(bits & ch438irqbits))
-					{
+					if(!(bits & ch438irqbits)) {
 						continue;
-					}
-					else
-					{
+					} else {
 						break;
 					}
 				}
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			}
-			else if ((irqbits & 0x00000080) == 0)
-			{
-				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1)
-				{
+			} else if((irqbits & 0x00000080) == 0) {
+				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i + 0x18;
 					ch438irqbits = readb(sp->port.board_membase + 0x280 + 0x4F) & sp->port.vector_mask;
-					if (ch438irqbits == 0x00000000)
-					{
+					if(ch438irqbits == 0x00000000) {
 						break;
 					}
-					if (!(bits & ch438irqbits))
-					{
+					if(!(bits & ch438irqbits)) {
 						continue;
-					}
-					else
-					{
+					} else {
 						break;
 					}
 				}
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			}
-			else
-			{
+			} else {
 				break;
 			}
 
-			if (pass_counter++ > INTERRUPT_COUNT)
-			{
+			if(pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	}
-	else // CH353_2S1P CH353_2S1PAR CH355_4S CH356_4S1P CH356_8S CH358_4S1P CH358_8S CH382_2S1P CH384_4S1P
-	{
-		while (1)
-		{
+	} else { // CH353_2S1P CH353_2S1PAR CH355_4S CH356_4S1P CH356_8S CH358_4S1P CH358_8S CH382_2S1P CH384_4S1P
+		while(1) {
 			irqbits = READ_INTERRUPT_VECTOR_BYTE(first_sp) & first_sp->port.vector_mask;
-			if (irqbits == 0x0000)
-			{
+			if(irqbits == 0x0000) {
 				break;
 			}
 
-			for (i = 0, bits = 1; i < max; i++, bits <<= 1)
-			{
-				if (!(bits & irqbits))
-				{
+			for(i = 0, bits = 1; i < max; i++, bits <<= 1) {
+				if(!(bits & irqbits)) {
 					continue;
 				}
 
@@ -4262,23 +3791,19 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if (iir & UART_IIR_NO_INT)
-				{
+				if(iir & UART_IIR_NO_INT) {
 					continue;
-				}
-				else
-				{
+				} else {
 					spin_lock(&sp->port.lock);
 					ser_handle_port(sp, iir);
 					spin_unlock(&sp->port.lock);
 				}
 			}
 
-			if (pass_counter++ > INTERRUPT_COUNT)
-			{
+			if(pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
 	}
-    return 0;
+	return 0;
 }

--- a/driver/wch_serial.c
+++ b/driver/wch_serial.c
@@ -157,15 +157,14 @@ static void WRITE_UART_MCR(struct wch_ser_port *, unsigned char);
 static void WRITE_UART_DLL(struct wch_ser_port *, int);
 static void WRITE_UART_DLM(struct wch_ser_port *, int);
 
-static
-unsigned char
+static unsigned char
 READ_INTERRUPT_VECTOR_BYTE(
     struct wch_ser_port *sp
 )
 {
 	unsigned char data = 0;
 
-	if(sp->port.vector) {
+	if (sp->port.vector) {
 		data = inb(sp->port.vector);
 
 		return data;
@@ -174,8 +173,7 @@ READ_INTERRUPT_VECTOR_BYTE(
 	return 0;
 }
 
-static
-unsigned int
+static unsigned int
 READ_INTERRUPT_VECTOR_WORD(
     struct wch_ser_port *sp
 )
@@ -184,7 +182,7 @@ READ_INTERRUPT_VECTOR_WORD(
 	unsigned int vet1 = 0;
 	unsigned int vet2 = 0;
 
-	if(sp->port.vector) {
+	if (sp->port.vector) {
 		vet1 = inb(sp->port.vector);
 		vet2 = inb(sp->port.vector - 0x10);
 
@@ -197,31 +195,29 @@ READ_INTERRUPT_VECTOR_WORD(
 	return 0;
 }
 
-static
-unsigned long
+static unsigned long
 READ_INTERRUPT_VECTOR_DWORD(
     struct wch_ser_port *sp
 )
 {
 	unsigned long data = 0;
 
-	if(sp->port.iobase) {
+	if (sp->port.iobase) {
 		data = inl(sp->port.chip_iobase + 0xE8);
 	}
 
 	return data;
 }
 
-static
-unsigned char
+static unsigned char
 READ_UART_RX(
     struct wch_ser_port *sp
 )
 {
 	unsigned char data = 0;
 
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			data = readb(sp->port.port_membase + UART_RX);
 		} else {
 			data = inb(sp->port.iobase + UART_RX);
@@ -233,15 +229,14 @@ READ_UART_RX(
 	return 0;
 }
 
-static
-void
+static void
 WRITE_UART_TX(
     struct wch_ser_port *sp,
     unsigned char data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_TX);
 		} else {
 			outb(data, sp->port.iobase + UART_TX);
@@ -249,15 +244,14 @@ WRITE_UART_TX(
 	}
 }
 
-static
-void
+static void
 WRITE_UART_IER(
     struct wch_ser_port *sp,
     unsigned char data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_IER);
 		} else {
 			outb(data, sp->port.iobase + UART_IER);
@@ -265,16 +259,15 @@ WRITE_UART_IER(
 	}
 }
 
-static
-unsigned char
+static unsigned char
 READ_UART_IIR(
     struct wch_ser_port *sp
 )
 {
 	unsigned char data = 0;
 
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			data = readb(sp->port.port_membase + UART_IIR);
 		} else {
 			data = inb(sp->port.iobase + UART_IIR);
@@ -286,15 +279,14 @@ READ_UART_IIR(
 	return 0;
 }
 
-static
-void
+static void
 WRITE_UART_FCR(
     struct wch_ser_port *sp,
     unsigned char data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_FCR);
 		} else {
 			outb(data, sp->port.iobase + UART_FCR);
@@ -302,16 +294,15 @@ WRITE_UART_FCR(
 	}
 }
 
-static
-unsigned char
+static unsigned char
 READ_UART_LCR(
     struct wch_ser_port *sp
 )
 {
 	unsigned char data = 0;
 
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			data = readb(sp->port.port_membase + UART_LCR);
 		} else {
 			data = inb(sp->port.iobase + UART_LCR);
@@ -323,15 +314,14 @@ READ_UART_LCR(
 	return 0;
 }
 
-static
-void
+static void
 WRITE_UART_LCR(
     struct wch_ser_port *sp,
     unsigned char data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_LCR);
 		} else {
 			outb(data, sp->port.iobase + UART_LCR);
@@ -339,15 +329,14 @@ WRITE_UART_LCR(
 	}
 }
 
-static
-void
+static void
 WRITE_UART_MCR(
     struct wch_ser_port *sp,
     unsigned char data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_MCR);
 		} else {
 			outb(data, sp->port.iobase + UART_MCR);
@@ -355,16 +344,15 @@ WRITE_UART_MCR(
 	}
 }
 
-static
-unsigned char
+static unsigned char
 READ_UART_LSR(
     struct wch_ser_port *sp
 )
 {
 	unsigned char data = 0;
 
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			data = readb(sp->port.port_membase + UART_LSR);
 		} else {
 			data = inb(sp->port.iobase + UART_LSR);
@@ -376,17 +364,15 @@ READ_UART_LSR(
 	return 0;
 }
 
-
-static
-unsigned char
+static unsigned char
 READ_UART_MSR(
     struct wch_ser_port *sp
 )
 {
 	unsigned char data = 0;
 
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			data = readb(sp->port.port_membase + UART_MSR);
 		} else {
 			data = inb(sp->port.iobase + UART_MSR);
@@ -398,16 +384,14 @@ READ_UART_MSR(
 	return 0;
 }
 
-
-static
-void
+static void
 WRITE_UART_DLL(
     struct wch_ser_port *sp,
     int data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_DLL);
 		} else {
 			outb(data, sp->port.iobase + UART_DLL);
@@ -415,15 +399,14 @@ WRITE_UART_DLL(
 	}
 }
 
-static
-void
+static void
 WRITE_UART_DLM(
     struct wch_ser_port *sp,
     int data
 )
 {
-	if(sp->port.iobase) {
-		if(ch365_32s) {
+	if (sp->port.iobase) {
+		if (ch365_32s) {
 			writeb(data, sp->port.port_membase + UART_DLM);
 		} else {
 			outb(data, sp->port.iobase + UART_DLM);
@@ -442,22 +425,21 @@ ser_handle_cts_change(
 
 	port->icount.cts++;
 
-	if(info->flags & WCH_UIF_CTS_FLOW) {
-		if(tty->hw_stopped) {
-			if(status) {
+	if (info->flags & WCH_UIF_CTS_FLOW) {
+		if (tty->hw_stopped) {
+			if (status) {
 				tty->hw_stopped = 0;
 				wch_ser_start_tx(port, 0);
 				ser_write_wakeup(port);
 			}
 		} else {
-			if(!status) {
+			if (!status) {
 				tty->hw_stopped = 1;
 				wch_ser_stop_tx(port, 0);
 			}
 		}
 	}
 }
-
 
 static _INLINE_ void
 ser_update_mctrl(
@@ -474,7 +456,7 @@ ser_update_mctrl(
 	old = port->mctrl;
 	port->mctrl = (old & ~clear) | set;
 
-	if(old != port->mctrl) {
+	if (old != port->mctrl) {
 		wch_ser_set_mctrl(port, port->mctrl);
 	}
 	spin_unlock_irqrestore(&port->lock, flags);
@@ -484,7 +466,6 @@ ser_update_mctrl(
 #define set_mctrl(port, set) ser_update_mctrl(port, set, 0)
 #define clear_mctrl(port, clear) ser_update_mctrl(port, 0, clear)
 
-
 static void
 ser_write_wakeup(
     struct ser_port *port
@@ -493,7 +474,6 @@ ser_write_wakeup(
 	struct ser_info *info = port->info;
 	tasklet_schedule(&info->tlet);
 }
-
 
 static void
 ser_stop(
@@ -505,7 +485,7 @@ ser_stop(
 	unsigned long flags;
 	int line = WCH_SER_DEVNUM(tty);
 
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
@@ -517,7 +497,6 @@ ser_stop(
 	spin_unlock_irqrestore(&port->lock, flags);
 }
 
-
 static void
 _ser_start(
     struct tty_struct *tty
@@ -525,11 +504,11 @@ _ser_start(
 {
 	struct ser_state *state = tty->driver_data;
 	struct ser_port *port = state->port;
-	if(!ser_circ_empty(&state->info->xmit) && state->info->xmit.buf && !tty->stopped && !tty->hw_stopped) {
+
+	if (!ser_circ_empty(&state->info->xmit) && state->info->xmit.buf && !tty->stopped && !tty->hw_stopped) {
 		wch_ser_start_tx(port, 1);
 	}
 }
-
 
 static void
 ser_start(
@@ -541,7 +520,7 @@ ser_start(
 	unsigned long flags;
 
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
@@ -553,7 +532,6 @@ ser_start(
 	spin_unlock_irqrestore(&port->lock, flags);
 }
 
-
 static void
 ser_tasklet_action(
     unsigned long data
@@ -562,27 +540,26 @@ ser_tasklet_action(
 	struct ser_state *state = (struct ser_state *)data;
 	struct tty_struct *tty = NULL;
 	tty = state->info->tty;
-	if(tty) {
+	if (tty) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31))
-		if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup) {
+		if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup) {
 			tty->ldisc->ops->write_wakeup(tty);
 		}
 
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27) && LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,30))
 		{
-			if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup) {
+			if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup) {
 				tty->ldisc.ops->write_wakeup(tty);
 			}
 		}
 #else
-		if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup) {
+		if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup) {
 			tty->ldisc.write_wakeup(tty);
 		}
 #endif
 		wake_up_interruptible(&tty->write_wait);
 	}
 }
-
 
 static int
 ser_startup(
@@ -595,24 +572,24 @@ ser_startup(
 	unsigned long page;
 	int retval = 0;
 
-	if(info->flags & WCH_UIF_INITIALIZED) {
+	if (info->flags & WCH_UIF_INITIALIZED) {
 		return 0;
 	}
 
 
-	if(info->tty) {
+	if (info->tty) {
 		set_bit(TTY_IO_ERROR, &info->tty->flags);
 	}
 
 
-	if(port->type == PORT_UNKNOWN) {
+	if (port->type == PORT_UNKNOWN) {
 		return 0;
 	}
 
 
-	if(!info->xmit.buf) {
+	if (!info->xmit.buf) {
 		page = get_zeroed_page(GFP_KERNEL);
-		if(!page) {
+		if (!page) {
 			return -ENOMEM;
 		}
 
@@ -628,16 +605,15 @@ ser_startup(
 
 	retval = wch_ser_startup(port);
 
-	if(retval == 0) {
-		if(init_hw) {
+	if (retval == 0) {
+		if (init_hw) {
 			ser_change_speed(state, NULL);
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-			if(info->tty->termios->c_cflag & CBAUD)
+			if (info->tty->termios->c_cflag & CBAUD)
 #else
-			if(info->tty->termios.c_cflag & CBAUD)
+			if (info->tty->termios.c_cflag & CBAUD)
 #endif
 			{
-				printk("%s set rtsdtr\n", __func__);
 				set_mctrl(port, TIOCM_RTS | TIOCM_DTR);
 			}
 		}
@@ -648,14 +624,13 @@ ser_startup(
 	}
 
 
-	if(retval && capable(CAP_SYS_ADMIN)) {
+	if (retval && capable(CAP_SYS_ADMIN)) {
 		retval = 0;
 	}
 	set_mctrl(port, TIOCM_OUT2);
 
 	return retval;
 }
-
 
 static void
 ser_shutdown(
@@ -666,13 +641,13 @@ ser_shutdown(
 	struct ser_port *port = state->port;
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 
-	if(!(info->flags & WCH_UIF_INITIALIZED)) {
+	if (!(info->flags & WCH_UIF_INITIALIZED)) {
 		return;
 	}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-	if(!info->tty || (info->tty->termios->c_cflag & HUPCL))
+	if (!info->tty || (info->tty->termios->c_cflag & HUPCL))
 #else
-	if(!info->tty || (info->tty->termios.c_cflag & HUPCL))
+	if (!info->tty || (info->tty->termios.c_cflag & HUPCL))
 #endif
 	{
 		clear_mctrl(port, TIOCM_DTR | TIOCM_RTS);
@@ -686,16 +661,16 @@ ser_shutdown(
 	synchronize_irq(port->irq);
 #endif
 
-	if(info->xmit.buf) {
+	if (info->xmit.buf) {
 		free_page((unsigned long)info->xmit.buf);
 		info->xmit.buf = NULL;
-		if(info->tmpbuf)
+		if (info->tmpbuf)
 			info->tmpbuf = NULL;
 	}
 
 	tasklet_kill(&info->tlet);
 
-	if(info->tty) {
+	if (info->tty) {
 		set_bit(TTY_IO_ERROR, &info->tty->flags);
 	}
 
@@ -706,7 +681,6 @@ ser_shutdown(
 	info->flags &= ~WCH_UIF_INITIALIZED;
 }
 
-
 static _INLINE_ void
 _ser_put_char(
     struct ser_port *port,
@@ -715,19 +689,18 @@ _ser_put_char(
 )
 {
 	unsigned long flags;
-	if(!circ->buf) {
+	if (!circ->buf) {
 		return;
 	}
 
 	spin_lock_irqsave(&port->lock, flags);
 
-	if(ser_circ_chars_free(circ) != 0) {
+	if (ser_circ_chars_free(circ) != 0) {
 		circ->buf[circ->head] = c;
 		circ->head = (circ->head + 1) & (WCH_UART_XMIT_SIZE - 1);
 	}
 	spin_unlock_irqrestore(&port->lock, flags);
 }
-
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
 static int
@@ -745,7 +718,8 @@ ser_put_char(
 {
 	struct ser_state *state = NULL;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
 		return 0;
 #else
@@ -759,9 +733,7 @@ ser_put_char(
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
 	return 0;
 #endif
-
 }
-
 
 static void
 ser_flush_chars(
@@ -769,13 +741,13 @@ ser_flush_chars(
 )
 {
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
 	ser_start(tty);
 }
-
 
 static int
 ser_chars_in_buffer(
@@ -784,14 +756,14 @@ ser_chars_in_buffer(
 {
 	struct ser_state *state = NULL;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return 0;
 	}
 
 	state = tty->driver_data;
 	return ser_circ_chars_pending(&state->info->xmit);
 }
-
 
 static void
 ser_flush_buffer(
@@ -802,14 +774,15 @@ ser_flush_buffer(
 	struct ser_port *port = NULL;
 	unsigned long flags;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
 	state = tty->driver_data;
 	port = state->port;
 
-	if(!state || !state->info) {
+	if (!state || !state->info) {
 		return;
 	}
 
@@ -820,23 +793,22 @@ ser_flush_buffer(
 	wake_up_interruptible(&tty->write_wait);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31))
-	if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup) {
+	if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc->ops->write_wakeup) {
 		(tty->ldisc->ops->write_wakeup)(tty);
 	}
 
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27) && LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,30))
 
-	if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup) {
+	if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.ops->write_wakeup) {
 		(tty->ldisc.ops->write_wakeup)(tty);
 	}
 
 #else
-	if((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup) {
+	if ((tty->flags & (1 << TTY_DO_WRITE_WAKEUP)) && tty->ldisc.write_wakeup) {
 		(tty->ldisc.write_wakeup)(tty);
 	}
 #endif
 }
-
 
 static void
 ser_send_xchar(
@@ -848,7 +820,8 @@ ser_send_xchar(
 	struct ser_port *port = NULL;
 	unsigned long flags;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
@@ -856,13 +829,12 @@ ser_send_xchar(
 	port = state->port;
 	port->x_char = ch;
 
-	if(ch) {
+	if (ch) {
 		spin_lock_irqsave(&port->lock, flags);
 		wch_ser_start_tx(port, 0);
 		spin_unlock_irqrestore(&port->lock, flags);
 	}
 }
-
 
 static void
 ser_throttle(
@@ -872,28 +844,27 @@ ser_throttle(
 	struct ser_state *state = NULL;
 	struct ser_port *port = NULL;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
 	state = tty->driver_data;
 	port = state->port;
-
 	port->ldisc_stop_rx = 1;
 
-	if(I_IXOFF(tty)) {
+	if (I_IXOFF(tty)) {
 		ser_send_xchar(tty, STOP_CHAR(tty));
 	}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-	if(tty->termios->c_cflag & CRTSCTS)
+	if (tty->termios->c_cflag & CRTSCTS)
 #else
-	if(tty->termios.c_cflag & CRTSCTS)
+	if (tty->termios.c_cflag & CRTSCTS)
 #endif
 	{
 		clear_mctrl(state->port, TIOCM_RTS);
 	}
 }
-
 
 static void
 ser_unthrottle(
@@ -903,32 +874,31 @@ ser_unthrottle(
 	struct ser_state *state = NULL;
 	struct ser_port *port = NULL;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
 	state = tty->driver_data;
 	port = state->port;
-
 	port->ldisc_stop_rx = 0;
 
-	if(I_IXOFF(tty)) {
-		if(port->x_char) {
+	if (I_IXOFF(tty)) {
+		if (port->x_char) {
 			port->x_char = 0;
 		} else {
 			ser_send_xchar(tty, START_CHAR(tty));
 		}
 	}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-	if(tty->termios->c_cflag & CRTSCTS)
+	if (tty->termios->c_cflag & CRTSCTS)
 #else
-	if(tty->termios.c_cflag & CRTSCTS)
+	if (tty->termios.c_cflag & CRTSCTS)
 #endif
 	{
 		set_mctrl(port, TIOCM_RTS);
 	}
 }
-
 
 static int
 ser_get_info(
@@ -943,7 +913,7 @@ ser_get_info(
 	tmp.line = port->line;
 	tmp.port = port->iobase;
 
-	if(WCH_HIGH_BITS_OFFSET) {
+	if (WCH_HIGH_BITS_OFFSET) {
 		tmp.port_high = (long) port->iobase >> WCH_HIGH_BITS_OFFSET;
 	}
 
@@ -956,13 +926,12 @@ ser_get_info(
 	tmp.custom_divisor = port->custom_divisor;
 	tmp.io_type = port->iotype;
 
-	if(copy_to_user(retinfo, &tmp, sizeof(*retinfo))) {
+	if (copy_to_user(retinfo, &tmp, sizeof(*retinfo))) {
 		return -EFAULT;
 	}
 
 	return 0;
 }
-
 
 static int
 ser_set_info(
@@ -981,13 +950,13 @@ ser_set_info(
 	unsigned int old_flags;
 	unsigned int new_flags;
 	int retval = 0;
-	if(copy_from_user(&new_serial, newinfo, sizeof(new_serial))) {
+	if (copy_from_user(&new_serial, newinfo, sizeof(new_serial))) {
 		return -EFAULT;
 	}
 
 	new_port = new_serial.port;
 
-	if(WCH_HIGH_BITS_OFFSET) {
+	if (WCH_HIGH_BITS_OFFSET) {
 		new_port += (unsigned long) new_serial.port_high << WCH_HIGH_BITS_OFFSET;
 	}
 
@@ -1010,15 +979,15 @@ ser_set_info(
 	new_flags = new_serial.flags;
 	old_custom_divisor = port->custom_divisor;
 
-	if(!capable(CAP_SYS_ADMIN)) {
+	if (!capable(CAP_SYS_ADMIN)) {
 		retval = -EPERM;
-		if(change_irq ||
-		   change_port ||
-		   (new_serial.baud_base != port->uartclk / 16) ||
-		   (close_delay != state->close_delay) ||
-		   (closing_wait != state->closing_wait) ||
-		   (new_serial.xmit_fifo_size != port->fifosize) ||
-		   (((new_flags ^ old_flags) & ~WCH_UPF_USR_MASK) != 0)) {
+		if (change_irq ||
+		    change_port ||
+		    (new_serial.baud_base != port->uartclk / 16) ||
+		    (close_delay != state->close_delay) ||
+		    (closing_wait != state->closing_wait) ||
+		    (new_serial.xmit_fifo_size != port->fifosize) ||
+		    (((new_flags ^ old_flags) & ~WCH_UPF_USR_MASK) != 0)) {
 			goto exit;
 		}
 
@@ -1027,18 +996,18 @@ ser_set_info(
 		goto check_and_exit;
 	}
 
-	if(change_port || change_irq) {
+	if (change_port || change_irq) {
 		retval = -EBUSY;
 
 
-		if(wch_ser_users(state) > 1) {
+		if (wch_ser_users(state) > 1) {
 			goto exit;
 		}
 
 		ser_shutdown(state);
 	}
 
-	if(change_port) {
+	if (change_port) {
 		unsigned long old_iobase;
 		unsigned int old_type;
 		unsigned int old_iotype;
@@ -1048,7 +1017,7 @@ ser_set_info(
 		old_iotype = port->iotype;
 
 
-		if(old_type != PORT_UNKNOWN) {
+		if (old_type != PORT_UNKNOWN) {
 			wch_ser_release_io(port);
 		}
 
@@ -1067,20 +1036,20 @@ ser_set_info(
 	state->closing_wait = closing_wait;
 	port->fifosize = new_serial.xmit_fifo_size;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-	if(state->info->tty) {
+	if (state->info->tty) {
 		state->info->tty->low_latency = (port->flags & WCH_UPF_LOW_LATENCY) ? 1 : 0;
 	}
 #endif
 check_and_exit:
 	retval = 0;
-	if(port->type == PORT_UNKNOWN) {
+	if (port->type == PORT_UNKNOWN) {
 		goto exit;
 	}
 
-	if(state->info->flags & WCH_UIF_INITIALIZED) {
-		if(((old_flags ^ port->flags) & WCH_UPF_SPD_MASK) || old_custom_divisor != port->custom_divisor) {
+	if (state->info->flags & WCH_UIF_INITIALIZED) {
+		if (((old_flags ^ port->flags) & WCH_UPF_SPD_MASK) || old_custom_divisor != port->custom_divisor) {
 
-			if(port->flags & WCH_UPF_SPD_MASK) {
+			if (port->flags & WCH_UPF_SPD_MASK) {
 				printk("WCH Info : %s sets custom speed on ttyWCH%d. This is deprecated.\n", current->comm, port->line);
 			}
 			ser_change_speed(state, NULL);
@@ -1094,7 +1063,6 @@ exit:
 	return retval;
 }
 
-
 static int
 ser_write_room(
     struct tty_struct *tty
@@ -1103,7 +1071,7 @@ ser_write_room(
 	struct ser_state *state = NULL;
 	int line = WCH_SER_DEVNUM(tty);
 	int status = 0;
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return 0;
 	}
 
@@ -1112,7 +1080,6 @@ ser_write_room(
 	status = ser_circ_chars_free(&state->info->xmit);
 	return status;
 }
-
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,10))
 static int
@@ -1137,32 +1104,32 @@ ser_write(
 	unsigned long flags;
 	int c;
 	int ret = 0;
-	if(!state || !state->info) {
+	if (!state || !state->info) {
 		return -EL3HLT;
 	}
 
 	port = state->port;
 	circ = &state->info->xmit;
 
-	if(!circ->buf) {
+	if (!circ->buf) {
 		return 0;
 	}
 
 	spin_lock_irqsave(&port->lock, flags);
-	while(1) {
+	while (1) {
 		c = CIRC_SPACE_TO_END(circ->head, circ->tail, WCH_UART_XMIT_SIZE);
-		if(count < c) {
+		if (count < c) {
 			c = count;
 		}
 
-		if(c <= 0) {
+		if (c <= 0) {
 			break;
 		}
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,6,9))
 		memcpy(circ->buf + circ->head, buf, c);
 #else
-		if(from_user) {
-			if(copy_from_user((circ->buf + circ->head), buf, c) == c) {
+		if (from_user) {
+			if (copy_from_user((circ->buf + circ->head), buf, c) == c) {
 				ret = -EFAULT;
 				break;
 			}
@@ -1225,7 +1192,7 @@ ser_tiocmget(
 	int result = -EIO;
 	int line = WCH_SER_DEVNUM(tty);
 
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return 0;
 	}
 
@@ -1234,7 +1201,7 @@ ser_tiocmget(
 
 	down(&state->sem);
 
-	if(!(tty->flags & (1 << TTY_IO_ERROR))) {
+	if (!(tty->flags & (1 << TTY_IO_ERROR))) {
 		result = port->mctrl;
 		result |= wch_ser_get_mctrl(port);
 	}
@@ -1256,7 +1223,7 @@ ser_tiocmset(
 	int ret = -EIO;
 	int line = WCH_SER_DEVNUM(tty);
 
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return 0;
 	}
 
@@ -1265,7 +1232,7 @@ ser_tiocmset(
 
 	down(&state->sem);
 
-	if(!(tty->flags & (1 << TTY_IO_ERROR))) {
+	if (!(tty->flags & (1 << TTY_IO_ERROR))) {
 		ser_update_mctrl(port, set, clear);
 		ret = 0;
 	}
@@ -1286,7 +1253,7 @@ ser_tiocmget(
 	struct ser_port *port;
 	int result = -EIO;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return 0;
 	}
 
@@ -1295,7 +1262,7 @@ ser_tiocmget(
 
 	down(&state->sem);
 
-	if((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR))) {
+	if ((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR))) {
 		result = port->mctrl;
 		result |= wch_ser_get_mctrl(port);
 	}
@@ -1304,7 +1271,6 @@ ser_tiocmget(
 
 	return result;
 }
-
 
 static int
 ser_tiocmset(
@@ -1318,7 +1284,7 @@ ser_tiocmset(
 	struct ser_port *port;
 	int ret = -EIO;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return 0;
 	}
 
@@ -1327,7 +1293,7 @@ ser_tiocmset(
 
 	down(&state->sem);
 
-	if((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR))) {
+	if ((!file || !tty_hung_up_p(file)) && !(tty->flags & (1 << TTY_IO_ERROR))) {
 		ser_update_mctrl(port, set, clear);
 		ret = 0;
 	}
@@ -1336,7 +1302,6 @@ ser_tiocmset(
 
 	return ret;
 }
-
 
 #else
 static int
@@ -1348,19 +1313,19 @@ ser_get_modem_info(
 	struct ser_port *port = NULL;
 	int line;
 	unsigned int result;
-	if(!state) {
+	if (!state) {
 		return -EIO;
 	}
 
 	port = state->port;
 
-	if(!port) {
+	if (!port) {
 		return -EIO;
 	}
 
 	line = port->line;
 
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return -EIO;
 	}
 
@@ -1370,7 +1335,6 @@ ser_get_modem_info(
 	put_user(result, (unsigned long *)value);
 	return 0;
 }
-
 
 static int
 ser_set_modem_info(
@@ -1384,69 +1348,69 @@ ser_set_modem_info(
 	unsigned int set = 0;
 	unsigned int clr = 0;
 	unsigned int arg;
-	if(!state) {
+	if (!state) {
 		return -EIO;
 	}
 
 	port = state->port;
 
-	if(!port) {
+	if (!port) {
 		return -EIO;
 	}
 
 	line = port->line;
 
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return -EIO;
 	}
 
 	get_user(arg, (unsigned long *)value);
 
-	switch(cmd) {
+	switch (cmd) {
 	case TIOCMBIS: {
-		if(arg & TIOCM_RTS) {
+		if (arg & TIOCM_RTS) {
 			set |= TIOCM_RTS;
 		}
 
-		if(arg & TIOCM_DTR) {
+		if (arg & TIOCM_DTR) {
 			set |= TIOCM_DTR;
 		}
 
-		if(arg & TIOCM_LOOP) {
+		if (arg & TIOCM_LOOP) {
 			set |= TIOCM_LOOP;
 		}
 		break;
 	}
 
 	case TIOCMBIC: {
-		if(arg & TIOCM_RTS) {
+		if (arg & TIOCM_RTS) {
 			clr |= TIOCM_RTS;
 		}
 
-		if(arg & TIOCM_DTR) {
+		if (arg & TIOCM_DTR) {
 			clr |= TIOCM_DTR;
 		}
 
-		if(arg & TIOCM_LOOP) {
+		if (arg & TIOCM_LOOP) {
 			clr |= TIOCM_LOOP;
 		}
 		break;
 	}
 
 	case TIOCMSET: {
-		if(arg & TIOCM_RTS) {
+		if (arg & TIOCM_RTS) {
 			set |= TIOCM_RTS;
 		} else {
 			clr |= TIOCM_RTS;
 		}
 
-		if(arg & TIOCM_DTR) {
+		if (arg & TIOCM_DTR) {
 			set |= TIOCM_DTR;
 		} else {
 			clr |= TIOCM_DTR;
 		}
 
-		if(arg & TIOCM_LOOP) {
+		if (arg & TIOCM_LOOP) {
 			set |= TIOCM_LOOP;
 		} else {
 			clr |= TIOCM_LOOP;
@@ -1463,7 +1427,6 @@ ser_set_modem_info(
 	return 0;
 }
 #endif
-
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
 static int
@@ -1482,7 +1445,7 @@ ser_break_ctl(
 	struct ser_state *state = NULL;
 	struct ser_port *port = NULL;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
 		return 0;
 #else
@@ -1495,7 +1458,7 @@ ser_break_ctl(
 
 	down(&state->sem);
 
-	if(port->type != PORT_UNKNOWN) {
+	if (port->type != PORT_UNKNOWN) {
 		wch_ser_break_ctl(port, break_state);
 	}
 
@@ -1505,7 +1468,6 @@ ser_break_ctl(
 	return 0;
 #endif
 }
-
 
 static int
 ser_wait_modem_status(
@@ -1527,29 +1489,25 @@ ser_wait_modem_status(
 
 	add_wait_queue(&state->info->delta_msr_wait, &wait);
 
-	for(;;) {
+	for (;;) {
 		spin_lock_irq(&port->lock);
 		memcpy(&cnow, &port->icount, sizeof(struct ser_icount));
 		spin_unlock_irq(&port->lock);
-
 		set_current_state(TASK_INTERRUPTIBLE);
 
-		if(((arg & TIOCM_RNG) && (cnow.rng != cprev.rng)) ||
-		   ((arg & TIOCM_DSR) && (cnow.dsr != cprev.dsr)) ||
-		   ((arg & TIOCM_CD)  && (cnow.dcd != cprev.dcd)) ||
-		   ((arg & TIOCM_CTS) && (cnow.cts != cprev.cts))) {
+		if (((arg & TIOCM_RNG) && (cnow.rng != cprev.rng)) ||
+		    ((arg & TIOCM_DSR) && (cnow.dsr != cprev.dsr)) ||
+		    ((arg & TIOCM_CD)  && (cnow.dcd != cprev.dcd)) ||
+		    ((arg & TIOCM_CTS) && (cnow.cts != cprev.cts))) {
 			ret = 0;
 			break;
 		}
 
 		schedule();
-
-
-		if(signal_pending(current)) {
+		if (signal_pending(current)) {
 			ret = -ERESTARTSYS;
 			break;
 		}
-
 		cprev = cnow;
 	}
 
@@ -1557,7 +1515,6 @@ ser_wait_modem_status(
 	remove_wait_queue(&state->info->delta_msr_wait, &wait);
 	return ret;
 }
-
 
 static int
 ser_get_count(
@@ -1610,14 +1567,14 @@ ser_ioctl(
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,0))
 	int status = 0;
 #endif
-	if(line < wch_ser_port_total_cnt) {
+	if (line < wch_ser_port_total_cnt) {
 		state = tty->driver_data;
 	}
 
 
-	switch(cmd) {
+	switch (cmd) {
 	case TIOCGSERIAL: {
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			ret = ser_get_info(state, (struct serial_struct *)arg);
 		}
 		break;
@@ -1625,7 +1582,7 @@ ser_ioctl(
 
 
 	case TIOCSSERIAL: {
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			state->port->setserial_flag = WCH_SER_BAUD_SETSERIAL;
 			ret = ser_set_info(state, (struct serial_struct *)arg);
 		}
@@ -1639,7 +1596,7 @@ ser_ioctl(
 		kterm = tty->termios;
 		mutex_unlock(&tty->throttle_mutex);
 
-		if(kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
+		if (kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
 			ret = -EFAULT;
 		else
 			ret = 0;
@@ -1649,7 +1606,7 @@ ser_ioctl(
 		kterm = tty->termios;
 		mutex_unlock(&tty->termios_mutex);
 
-		if(kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
+		if (kernel_termios_to_user_termios_1((struct termios __user *)arg, &kterm))
 			ret = -EFAULT;
 		else
 			ret = 0;
@@ -1659,18 +1616,16 @@ ser_ioctl(
 		kterm = tty->termios;
 		mutex_unlock(&tty->termios_mutex);
 
-		if(kernel_termios_to_user_termios_1((struct termios __user *)arg, kterm))
+		if (kernel_termios_to_user_termios_1((struct termios __user *)arg, kterm))
 			ret = -EFAULT;
 		else
 			ret = 0;
-
-
 #endif
 		break;
 	}
 
 	case TCSETS: {
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			state->port->flags &= ~(WCH_UPF_SPD_HI | WCH_UPF_SPD_VHI | WCH_UPF_SPD_SHI | WCH_UPF_SPD_WARP);
 			state->port->setserial_flag = WCH_SER_BAUD_NOTSETSER;
 			ser_update_termios(state);
@@ -1684,10 +1639,10 @@ ser_ioctl(
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,0))
 	case TIOCMGET: {
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			ret = verify_area(VERIFY_WRITE, (void *)arg, sizeof(unsigned int));
 
-			if(ret) {
+			if (ret) {
 				return ret;
 			}
 
@@ -1701,7 +1656,7 @@ ser_ioctl(
 	case TIOCMBIS:
 	case TIOCMBIC:
 	case TIOCMSET: {
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			status = ser_set_modem_info(state, cmd, (unsigned int *)arg);
 			return status;
 		}
@@ -1709,42 +1664,37 @@ ser_ioctl(
 	}
 #endif
 
-
 	case TIOCSERGWILD:
 	case TIOCSERSWILD: {
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			ret = 0;
 		}
 		break;
 	}
 	case TIOCMIWAIT:
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			ret = ser_wait_modem_status(state, arg);
 		}
 		break;
-
-
 	case TIOCGICOUNT:
-		if(line < wch_ser_port_total_cnt) {
+		if (line < wch_ser_port_total_cnt) {
 			ret = ser_get_count(state, (struct serial_icounter_struct *)arg);
 		}
 		break;
 
 	}
 
-	if(ret != -ENOIOCTLCMD) {
+	if (ret != -ENOIOCTLCMD) {
 		goto out;
 	}
 
-	if(tty->flags & (1 << TTY_IO_ERROR)) {
+	if (tty->flags & (1 << TTY_IO_ERROR)) {
 		ret = -EIO;
 		goto out;
 	}
 out:
 	return ret;
-
 }
-
 
 static void
 ser_hangup(
@@ -1753,7 +1703,8 @@ ser_hangup(
 {
 	struct ser_state *state = NULL;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
@@ -1761,7 +1712,7 @@ ser_hangup(
 
 	down(&state->sem);
 
-	if(state->info && state->info->flags & WCH_UIF_NORMAL_ACTIVE) {
+	if (state->info && state->info->flags & WCH_UIF_NORMAL_ACTIVE) {
 		ser_flush_buffer(tty);
 		ser_shutdown(state);
 		state->count = 0;
@@ -1774,7 +1725,6 @@ ser_hangup(
 	up(&state->sem);
 }
 
-
 unsigned int
 ser_get_divisor(
     struct ser_port *port,
@@ -1782,10 +1732,11 @@ ser_get_divisor(
 )
 {
 	unsigned int quot;
-	if(baud == 38400 && (port->flags & WCH_UPF_SPD_MASK) == WCH_UPF_SPD_CUST) {
+
+	if (baud == 38400 && (port->flags & WCH_UPF_SPD_MASK) == WCH_UPF_SPD_CUST) {
 		quot = port->custom_divisor;
 	} else {
-		if(baud > port->baud_base)
+		if (baud > port->baud_base)
 			quot = port->uartclk * 24 / 16 / baud;
 		else
 			quot = port->uartclk / 16 / baud;
@@ -1809,66 +1760,65 @@ ser_get_baud_rate(
 	int hung_up = 0;
 	unsigned int flags = port->flags & WCH_UPF_SPD_MASK;
 
-	if(port->flags & WCH_UPF_SPD_MASK) {
+	if (port->flags & WCH_UPF_SPD_MASK) {
 		altbaud = 38400;
-		if(flags == WCH_UPF_SPD_HI) {
+		if (flags == WCH_UPF_SPD_HI) {
 			altbaud = 57600;
 		}
 
-		if(flags == WCH_UPF_SPD_VHI) {
+		if (flags == WCH_UPF_SPD_VHI) {
 			altbaud = 115200;
 		}
 
-		if(flags == WCH_UPF_SPD_SHI) {
+		if (flags == WCH_UPF_SPD_SHI) {
 			altbaud = 230400;
 		}
 
-		if(flags == WCH_UPF_SPD_WARP) {
+		if (flags == WCH_UPF_SPD_WARP) {
 			altbaud = 460800;
 		}
 	}
 
-	for(try = 0; try < 2; try++) {
-					baud = tty_termios_baud_rate(termios);
+	for (try = 0; try < 2; try++) {
+		baud = tty_termios_baud_rate(termios);
 
-					if(try == 0 && baud == 38400)
-							baud = altbaud;
+		if (try == 0 && baud == 38400)
+				baud = altbaud;
 
-					if(baud == 0) {
-						hung_up = 1;
-						baud = 9600;
-					}
+		if (baud == 0) {
+			hung_up = 1;
+			baud = 9600;
+		}
 
-					if(baud >= min && baud <= max) {
-						return baud;
-					}
+		if (baud >= min && baud <= max) {
+			return baud;
+		}
 
-					termios->c_cflag &= ~CBAUD;
-					if(old) {
-						baud = tty_termios_baud_rate(old);
-						if(!hung_up)
-							tty_termios_encode_baud_rate(termios,
-							                             baud, baud);
-						old = NULL;
-						continue;
-					}
-					/*
-					 * As a last resort, if the range cannot be met then clip to
-					 * the nearest chip supported rate.
-					 */
-					if(!hung_up) {
-						if(baud <= min)
-							tty_termios_encode_baud_rate(termios,
-							                             min + 1, min + 1);
-						else
-							tty_termios_encode_baud_rate(termios,
-							                             max - 1, max - 1);
-					}
-				}
+		termios->c_cflag &= ~CBAUD;
+		if (old) {
+			baud = tty_termios_baud_rate(old);
+			if (!hung_up)
+				tty_termios_encode_baud_rate(termios,
+				                             baud, baud);
+			old = NULL;
+			continue;
+		}
+		/*
+		 * As a last resort, if the range cannot be met then clip to
+		 * the nearest chip supported rate.
+		 */
+		if (!hung_up) {
+			if (baud <= min)
+				tty_termios_encode_baud_rate(termios,
+				                             min + 1, min + 1);
+			else
+				tty_termios_encode_baud_rate(termios,
+				                             max - 1, max - 1);
+		}
+	}
 
 	return 0;
 }
-
 
 static void
 ser_change_speed(
@@ -1880,19 +1830,19 @@ ser_change_speed(
 	struct ser_port *port = state->port;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
 	struct WCHTERMIOS *termios;
-	if(!tty || !tty->termios || port->type == PORT_UNKNOWN) {
+	if (!tty || !tty->termios || port->type == PORT_UNKNOWN) {
 		return;
 	}
 
 	termios = tty->termios;
 
-	if(termios->c_cflag & CRTSCTS) {
+	if (termios->c_cflag & CRTSCTS) {
 		state->info->flags |= WCH_UIF_CTS_FLOW;
 	} else {
 		state->info->flags &= ~WCH_UIF_CTS_FLOW;
 	}
 
-	if(termios->c_cflag & CLOCAL) {
+	if (termios->c_cflag & CLOCAL) {
 		state->info->flags &= ~WCH_UIF_CHECK_CD;
 	} else {
 		state->info->flags |= WCH_UIF_CHECK_CD;
@@ -1900,17 +1850,17 @@ ser_change_speed(
 	wch_ser_set_termios(port, termios, old_termios);
 #else
 	struct WCHTERMIOS termios;
-	if(!tty || port->type == PORT_UNKNOWN) {
+	if (!tty || port->type == PORT_UNKNOWN) {
 		return;
 	}
 	termios = tty->termios;
-	if(termios.c_cflag & CRTSCTS) {
+	if (termios.c_cflag & CRTSCTS) {
 		state->info->flags |= WCH_UIF_CTS_FLOW;
 	} else {
 		state->info->flags &= ~WCH_UIF_CTS_FLOW;
 	}
 
-	if(termios.c_cflag & CLOCAL) {
+	if (termios.c_cflag & CLOCAL) {
 		state->info->flags &= ~WCH_UIF_CHECK_CD;
 	} else {
 		state->info->flags |= WCH_UIF_CHECK_CD;
@@ -1918,7 +1868,6 @@ ser_change_speed(
 	wch_ser_set_termios(port, &termios, old_termios);
 #endif
 }
-
 
 static void
 ser_set_termios(
@@ -1934,7 +1883,7 @@ ser_set_termios(
 	unsigned int cflag = tty->termios.c_cflag;
 #endif
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
@@ -1943,9 +1892,9 @@ ser_set_termios(
 #define RELEVANT_IFLAG(iflag)   ((iflag) & (IGNBRK|BRKINT|IGNPAR|PARMRK|INPCK))
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-	if((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios->c_iflag ^ old_termios->c_iflag) == 0)
+	if ((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios->c_iflag ^ old_termios->c_iflag) == 0)
 #else
-	if((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios.c_iflag ^ old_termios->c_iflag) == 0)
+	if ((cflag ^ old_termios->c_cflag) == 0 && RELEVANT_IFLAG(tty->termios.c_iflag ^ old_termios->c_iflag) == 0)
 #endif
 	{
 		return;
@@ -1954,28 +1903,26 @@ ser_set_termios(
 	ser_change_speed(state, old_termios);
 
 	/* Drop RTS and DTR */
-	if((cflag & CBAUD) == B0) {
+	if ((cflag & CBAUD) == B0) {
 		clear_mctrl(state->port, TIOCM_RTS | TIOCM_DTR);
 	} else {
 		/* Ensure RTS and DTR are raised when baudrate changed from 0 */
-		if(old_termios && ((old_termios->c_cflag & CBAUD) == B0)) {
+		if (old_termios && ((old_termios->c_cflag & CBAUD) == B0)) {
 			unsigned int mask = TIOCM_DTR;
-			if(!(cflag & CRTSCTS) || !test_bit(TTY_THROTTLED, &tty->flags)) {
+			if (!(cflag & CRTSCTS) || !test_bit(TTY_THROTTLED, &tty->flags)) {
 				mask |= TIOCM_RTS;
 			}
 			set_mctrl(state->port, mask);
 		}
 	}
 
-	if((old_termios->c_cflag & CRTSCTS) && !(cflag & CRTSCTS)) {
+	if ((old_termios->c_cflag & CRTSCTS) && !(cflag & CRTSCTS)) {
 		spin_lock_irqsave(&state->port->lock, flags);
 		tty->hw_stopped = 0;
 		_ser_start(tty);
 		spin_unlock_irqrestore(&state->port->lock, flags);
 	}
-
 }
-
 
 static void
 ser_update_termios(
@@ -1983,24 +1930,20 @@ ser_update_termios(
 )
 {
 	struct tty_struct *tty = state->info->tty;
-//    struct ser_port *port = state->port;
+	struct ser_port *port = state->port;
 
-	if(!(tty->flags & (1 << TTY_IO_ERROR))) {
+	if (!(tty->flags & (1 << TTY_IO_ERROR))) {
 		ser_change_speed(state, NULL);
-		// disclaimed on 20200929
-		/*
-		#if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
 		if (tty->termios->c_cflag & CBAUD)
-		#else
+#else
 		if (tty->termios.c_cflag & CBAUD)
-		#endif
+#endif
 		{
-		    set_mctrl(port, TIOCM_DTR | TIOCM_RTS);
+			set_mctrl(port, TIOCM_DTR | TIOCM_RTS);
 		}
-		*/
 	}
 }
-
 
 static void
 ser_update_timeout(
@@ -2010,7 +1953,8 @@ ser_update_timeout(
 )
 {
 	unsigned int bits;
-	switch(cflag & CSIZE) {
+
+	switch (cflag & CSIZE) {
 	case CS5:
 		bits = 7;
 		break;
@@ -2028,11 +1972,11 @@ ser_update_timeout(
 		break;
 	}
 
-	if(cflag & CSTOPB) {
+	if (cflag & CSTOPB) {
 		bits++;
 	}
 
-	if(cflag & PARENB) {
+	if (cflag & PARENB) {
 		bits++;
 	}
 
@@ -2040,7 +1984,6 @@ ser_update_timeout(
 
 	port->timeout = (HZ * bits) / baud + HZ / 50;
 }
-
 
 static struct
 ser_state *ser_get(
@@ -2054,31 +1997,31 @@ ser_state *ser_get(
 
 	state = drv->state + line;
 
-	if(down_interruptible(&state->sem)) {
+	if (down_interruptible(&state->sem)) {
 		state = ERR_PTR(-ERESTARTSYS);
 		goto out;
 	}
 
 	state->count++;
 
-	if(!state->port) {
+	if (!state->port) {
 		state->count--;
 		up(&state->sem);
 		state = ERR_PTR(-ENXIO);
 		goto out;
 	}
 
-	if(!state->port->iobase) {
+	if (!state->port->iobase) {
 		state->count--;
 		up(&state->sem);
 		state = ERR_PTR(-ENXIO);
 		goto out;
 	}
 
-	if(!state->info) {
+	if (!state->info) {
 		state->info = kmalloc(sizeof(struct ser_info), GFP_KERNEL);
 
-		if(state->info) {
+		if (state->info) {
 			memset(state->info, 0, sizeof(struct ser_info));
 			init_waitqueue_head(&state->info->open_wait);
 			init_waitqueue_head(&state->info->delta_msr_wait);
@@ -2098,7 +2041,6 @@ out:
 	return state;
 }
 
-
 static int
 ser_block_til_ready(
     struct file *filp,
@@ -2114,40 +2056,40 @@ ser_block_til_ready(
 
 	add_wait_queue(&info->open_wait, &wait);
 
-	while(1) {
+	while (1) {
 		set_current_state(TASK_INTERRUPTIBLE);
 
-		if(tty_hung_up_p(filp) || info->tty == NULL) {
+		if (tty_hung_up_p(filp) || info->tty == NULL) {
 			break;
 		}
 
-		if(!(info->flags & WCH_UIF_INITIALIZED)) {
+		if (!(info->flags & WCH_UIF_INITIALIZED)) {
 			break;
 		}
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-		if((filp->f_flags & O_NONBLOCK) ||
-		   (info->tty->termios->c_cflag & CLOCAL) ||
-		   (info->tty->flags & (1 << TTY_IO_ERROR)))
+		if ((filp->f_flags & O_NONBLOCK) ||
+		    (info->tty->termios->c_cflag & CLOCAL) ||
+		    (info->tty->flags & (1 << TTY_IO_ERROR)))
 #else
-		if((filp->f_flags & O_NONBLOCK) ||
-		   (info->tty->termios.c_cflag & CLOCAL) ||
-		   (info->tty->flags & (1 << TTY_IO_ERROR)))
+		if ((filp->f_flags & O_NONBLOCK) ||
+		    (info->tty->termios.c_cflag & CLOCAL) ||
+		    (info->tty->flags & (1 << TTY_IO_ERROR)))
 #endif
 		{
 			break;
 		}
 
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-		if(info->tty->termios->c_cflag & CBAUD)
+		if (info->tty->termios->c_cflag & CBAUD)
 #else
-		if(info->tty->termios.c_cflag & CBAUD)
+		if (info->tty->termios.c_cflag & CBAUD)
 #endif
 		{
 			set_mctrl(port, TIOCM_DTR);
 		}
 
-		if(wch_ser_get_mctrl(port) & TIOCM_CAR) {
+		if (wch_ser_get_mctrl(port) & TIOCM_CAR) {
 			break;
 		}
 
@@ -2155,7 +2097,7 @@ ser_block_til_ready(
 		schedule();
 		down(&state->sem);
 
-		if(signal_pending(current)) {
+		if (signal_pending(current)) {
 			break;
 		}
 	}
@@ -2166,17 +2108,16 @@ ser_block_til_ready(
 	state->count++;
 	info->blocked_open--;
 
-	if(signal_pending(current)) {
+	if (signal_pending(current)) {
 		return -ERESTARTSYS;
 	}
 
-	if(!info->tty || tty_hung_up_p(filp)) {
+	if (!info->tty || tty_hung_up_p(filp)) {
 		return -EAGAIN;
 	}
 
 	return 0;
 }
-
 
 static void
 ser_wait_until_sent(
@@ -2189,14 +2130,14 @@ ser_wait_until_sent(
 	unsigned long char_time;
 	unsigned long expire;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line >= wch_ser_port_total_cnt) {
+	if (line >= wch_ser_port_total_cnt) {
 		return;
 	}
 
 	state = tty->driver_data;
 	port = state->port;
 
-	if(port->type == PORT_UNKNOWN || port->fifosize == 0) {
+	if (port->type == PORT_UNKNOWN || port->fifosize == 0) {
 		return;
 	}
 
@@ -2204,29 +2145,29 @@ ser_wait_until_sent(
 
 	char_time = char_time / 5;
 
-	if(char_time == 0) {
+	if (char_time == 0) {
 		char_time = 1;
 	}
 
-	if(timeout && timeout < char_time) {
+	if (timeout && timeout < char_time) {
 		char_time = timeout;
 	}
 
-	if(timeout == 0 || timeout > 2 * port->timeout) {
+	if (timeout == 0 || timeout > 2 * port->timeout) {
 		timeout = 2 * port->timeout;
 	}
 
 	expire = jiffies + timeout;
 
-	while(!wch_ser_tx_empty(port)) {
+	while (!wch_ser_tx_empty(port)) {
 		set_current_state(TASK_INTERRUPTIBLE);
 		schedule_timeout(char_time);
 
-		if(signal_pending(current)) {
+		if (signal_pending(current)) {
 			break;
 		}
 
-		if(time_after(jiffies, expire)) {
+		if (time_after(jiffies, expire)) {
 			break;
 		}
 	}
@@ -2249,20 +2190,20 @@ ser_open(
 	int retval = 0;
 	int line = WCH_SER_DEVNUM(tty);
 
-	if(line < wch_ser_port_total_cnt) {
+	if (line < wch_ser_port_total_cnt) {
 		retval = -ENODEV;
 
-		if(line >= wch_ser_port_total_cnt) {
+		if (line >= wch_ser_port_total_cnt) {
 			goto fail;
 		}
 
 		state = ser_get(drv, line);
-		if(IS_ERR(state)) {
+		if (IS_ERR(state)) {
 			retval = PTR_ERR(state);
 			goto fail;
 		}
 
-		if(!state) {
+		if (!state) {
 			goto fail;
 		}
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 13))
@@ -2275,7 +2216,7 @@ ser_open(
 		tty->driver_data = state;
 		state->info->tty = tty;
 
-		if(tty_hung_up_p(filp)) {
+		if (tty_hung_up_p(filp)) {
 			retval = -EAGAIN;
 			state->count--;
 			up(&state->sem);
@@ -2287,13 +2228,13 @@ ser_open(
 #endif
 		retval = ser_startup(state, 0);
 
-		if(retval == 0) {
+		if (retval == 0) {
 			retval = ser_block_til_ready(filp, state);
 		}
 
 		up(&state->sem);
 
-		if(retval == 0 && !(state->info->flags & WCH_UIF_NORMAL_ACTIVE)) {
+		if (retval == 0 && !(state->info->flags & WCH_UIF_NORMAL_ACTIVE)) {
 			state->info->flags |= WCH_UIF_NORMAL_ACTIVE;
 
 			ser_update_termios(state);
@@ -2320,40 +2261,40 @@ ser_close(
 	struct ser_state *state = tty->driver_data;
 	struct ser_port *port;
 	int line = WCH_SER_DEVNUM(tty);
-	if(line < wch_ser_port_total_cnt) {
-		if(!state || !state->port) {
+	if (line < wch_ser_port_total_cnt) {
+		if (!state || !state->port) {
 			return;
 		}
 
 		port = state->port;
 
 		down(&state->sem);
-		if(tty_hung_up_p(filp)) {
+		if (tty_hung_up_p(filp)) {
 			goto done;
 		}
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
-		if((tty->count == 1) && (state->count != 1)) {
+		if ((tty->count == 1) && (state->count != 1)) {
 			printk("WCH Info : bad serial port count; tty->count is 1, state->count is %d\n", state->count);
 			state->count = 1;
 		}
 #endif
 
-		if(--state->count < 0) {
+		if (--state->count < 0) {
 			printk("WCH Info : bad serial port count for ttyWCH%d: %d\n", port->line, state->count);
 			state->count = 0;
 		}
 
-		if(state->count) {
+		if (state->count) {
 			goto done;
 		}
 
 		tty->closing = 1;
 
-		if(state->closing_wait != WCH_USF_CLOSING_WAIT_NONE) {
+		if (state->closing_wait != WCH_USF_CLOSING_WAIT_NONE) {
 			tty_wait_until_sent(tty, state->closing_wait);
 		}
 
-		if(state->info->flags & WCH_UIF_INITIALIZED) {
+		if (state->info->flags & WCH_UIF_INITIALIZED) {
 			unsigned long flags;
 			spin_lock_irqsave(&port->lock, flags);
 			wch_ser_stop_rx(port);
@@ -2368,34 +2309,34 @@ ser_close(
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31))
 
 		tty_ldisc_flush(tty);
-		/*        if (tty->ldisc->ops->flush_buffer)
-		        {
-		            tty->ldisc->ops->flush_buffer(tty);
-		        }
+		/*
+		if (tty->ldisc->ops->flush_buffer) {
+            tty->ldisc->ops->flush_buffer(tty);
+        }
 		*/
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27)&& LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,30) )
 		{
-			if(tty->ldisc.ops->flush_buffer) {
+			if (tty->ldisc.ops->flush_buffer) {
 				tty->ldisc.ops->flush_buffer(tty);
 			}
 		}
 #else
 
-		if(tty->ldisc.flush_buffer) {
+		if (tty->ldisc.flush_buffer) {
 			tty->ldisc.flush_buffer(tty);
 		}
 
 #endif
 
 		tty->closing = 0;
-		if(state->info->tty)
+		if (state->info->tty)
 			state->info->tty = NULL;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(3, 8, 0))
-		if(state->port0.tty)
+		if (state->port0.tty)
 			tty_port_tty_set(&state->port0, NULL);	//20140606 add
 #endif
-		if(state->info->blocked_open) {
-			if(state->close_delay) {
+		if (state->info->blocked_open) {
+			if (state->close_delay) {
 				set_current_state(TASK_INTERRUPTIBLE);
 				schedule_timeout(state->close_delay);
 			}
@@ -2413,9 +2354,7 @@ done:
 #endif
 
 	}
-
 }
-
 
 static void
 wch_ser_set_mctrl(
@@ -2426,23 +2365,23 @@ wch_ser_set_mctrl(
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 	unsigned char mcr = 0;
 
-	if(mctrl & TIOCM_RTS) {
+	if (mctrl & TIOCM_RTS) {
 		mcr |= UART_MCR_RTS;
 	}
 
-	if(mctrl & TIOCM_DTR) {
+	if (mctrl & TIOCM_DTR) {
 		mcr |= UART_MCR_DTR;
 	}
 
-	if(mctrl & TIOCM_OUT1) {
+	if (mctrl & TIOCM_OUT1) {
 		mcr |= UART_MCR_OUT1;
 	}
 
-	if(mctrl & TIOCM_OUT2) {
+	if (mctrl & TIOCM_OUT2) {
 		mcr |= UART_MCR_OUT2;
 	}
 
-	if(mctrl & TIOCM_LOOP) {
+	if (mctrl & TIOCM_LOOP) {
 		mcr |= UART_MCR_LOOP;
 	}
 
@@ -2450,7 +2389,6 @@ wch_ser_set_mctrl(
 
 	WRITE_UART_MCR(sp, mcr);
 }
-
 
 static unsigned int
 wch_ser_tx_empty(
@@ -2467,7 +2405,6 @@ wch_ser_tx_empty(
 	return ret;
 }
 
-
 static unsigned int
 wch_ser_get_mctrl(
     struct ser_port *port
@@ -2481,25 +2418,24 @@ wch_ser_get_mctrl(
 	status = READ_UART_MSR(sp);
 	spin_unlock_irqrestore(&sp->port.lock, flags);
 
-	if(status & UART_MSR_DCD) {
+	if (status & UART_MSR_DCD) {
 		ret |= TIOCM_CAR;
 	}
 
-	if(status & UART_MSR_RI) {
+	if (status & UART_MSR_RI) {
 		ret |= TIOCM_RNG;
 	}
 
-	if(status & UART_MSR_DSR) {
+	if (status & UART_MSR_DSR) {
 		ret |= TIOCM_DSR;
 	}
 
-	if(status & UART_MSR_CTS) {
+	if (status & UART_MSR_CTS) {
 		ret |= TIOCM_CTS;
 	}
 
 	return ret;
 }
-
 
 static void
 wch_ser_stop_tx(
@@ -2508,12 +2444,11 @@ wch_ser_stop_tx(
 )
 {
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
-	if(sp->ier & UART_IER_THRI) {
+	if (sp->ier & UART_IER_THRI) {
 		sp->ier &= ~UART_IER_THRI;
 		WRITE_UART_IER(sp, sp->ier);
 	}
 }
-
 
 static void
 wch_ser_start_tx(
@@ -2522,12 +2457,11 @@ wch_ser_start_tx(
 )
 {
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
-	if(!(sp->ier & UART_IER_THRI)) {
+	if (!(sp->ier & UART_IER_THRI)) {
 		sp->ier |= UART_IER_THRI;
 		WRITE_UART_IER(sp, sp->ier);
 	}
 }
-
 
 static void
 wch_ser_stop_rx(
@@ -2540,7 +2474,6 @@ wch_ser_stop_rx(
 	WRITE_UART_IER(sp, sp->ier);
 }
 
-
 static void
 wch_ser_enable_ms(
     struct ser_port *port
@@ -2550,7 +2483,6 @@ wch_ser_enable_ms(
 	sp->ier |= UART_IER_MSI;
 	WRITE_UART_IER(sp, sp->ier);
 }
-
 
 static void
 wch_ser_break_ctl(
@@ -2562,7 +2494,7 @@ wch_ser_break_ctl(
 	unsigned long flags;
 	spin_lock_irqsave(&sp->port.lock, flags);
 
-	if(break_state == -1) {
+	if (break_state == -1) {
 		sp->lcr |= UART_LCR_SBC;
 	} else {
 		sp->lcr &= ~UART_LCR_SBC;
@@ -2571,7 +2503,6 @@ wch_ser_break_ctl(
 	WRITE_UART_LCR(sp, sp->lcr);
 	spin_unlock_irqrestore(&sp->port.lock, flags);
 }
-
 
 static int
 wch_ser_startup(
@@ -2583,7 +2514,7 @@ wch_ser_startup(
 	sp->capabilities = wch_uart_config[sp->port.type].flags;
 	sp->mcr = 0;
 
-	if(sp->capabilities & UART_CLEAR_FIFO) {
+	if (sp->capabilities & UART_CLEAR_FIFO) {
 		WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO);
 		WRITE_UART_FCR(sp, UART_FCR_ENABLE_FIFO | UART_FCR_CLEAR_RCVR | UART_FCR_CLEAR_XMIT);
 		WRITE_UART_FCR(sp, 0);
@@ -2594,7 +2525,7 @@ wch_ser_startup(
 	(void) READ_UART_IIR(sp);
 	(void) READ_UART_MSR(sp);
 
-	if(!(sp->port.flags & WCH_UPF_BUGGY_UART) && (READ_UART_LSR(sp) == 0xff)) {
+	if (!(sp->port.flags & WCH_UPF_BUGGY_UART) && (READ_UART_LSR(sp) == 0xff)) {
 		printk("WCH Info : ttyWCH%d: LSR safety check engaged!\n", sp->port.line);
 		return -ENODEV;
 	}
@@ -2611,7 +2542,6 @@ wch_ser_startup(
 	(void) READ_UART_MSR(sp);
 	return 0;
 }
-
 
 static void
 wch_ser_shutdown(
@@ -2631,7 +2561,6 @@ wch_ser_shutdown(
 	(void) READ_UART_RX(sp);
 }
 
-
 static unsigned int
 wch_ser_get_divisor(
     struct ser_port *port,
@@ -2640,16 +2569,15 @@ wch_ser_get_divisor(
 {
 	unsigned int quot;
 
-	if((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 4)) {
+	if ((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 4)) {
 		quot = 0x8001;
-	} else if((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 8)) {
+	} else if ((port->flags & WCH_UPF_MAGIC_MULTIPLIER) && baud == (port->uartclk / 8)) {
 		quot = 0x8002;
 	} else {
 		quot = ser_get_divisor(port, baud);
 	}
 	return quot;
 }
-
 
 static void
 wch_ser_set_termios(
@@ -2664,7 +2592,7 @@ wch_ser_set_termios(
 	unsigned long flags;
 	unsigned int baud;
 	unsigned int quot;
-	switch(termios->c_cflag & CSIZE) {
+	switch (termios->c_cflag & CSIZE) {
 	case CS5:
 		cval = 0x00;
 		break;
@@ -2683,20 +2611,20 @@ wch_ser_set_termios(
 		break;
 	}
 
-	if(termios->c_cflag & CSTOPB) {
+	if (termios->c_cflag & CSTOPB) {
 		cval |= 0x04;
 	}
 
-	if(termios->c_cflag & PARENB) {
+	if (termios->c_cflag & PARENB) {
 		cval |= UART_LCR_PARITY;
 	}
 
-	if(!(termios->c_cflag & PARODD)) {
+	if (!(termios->c_cflag & PARODD)) {
 		cval |= UART_LCR_EPAR;
 	}
 
 #ifdef CMSPAR
-	if(termios->c_cflag & CMSPAR) {
+	if (termios->c_cflag & CMSPAR) {
 		cval |= UART_LCR_SPAR;
 	}
 #endif
@@ -2705,8 +2633,8 @@ wch_ser_set_termios(
 	baud = ser_get_baud_rate(port, termios, old, 0, port->uartclk * 24 / 16);
 
 	quot = wch_ser_get_divisor(port, baud);
-	if(sp->capabilities & UART_USE_FIFO) {
-		if(baud < 2400) {
+	if (sp->capabilities & UART_USE_FIFO) {
+		if (baud < 2400) {
 			fcr = UART_FCR_ENABLE_FIFO | UART_FCR_TRIGGER_1;
 		} else {
 			fcr = UART_FCR_ENABLE_FIFO | UART_FCR_TRIGGER_14;
@@ -2714,7 +2642,7 @@ wch_ser_set_termios(
 	}
 
 	/* added on 20210323 */
-	if(baud > sp->port.baud_base) {
+	if (baud > sp->port.baud_base) {
 		sp->ier |= 1 << 5;
 	} else {
 		sp->ier &= ~(1 << 5);
@@ -2722,7 +2650,7 @@ wch_ser_set_termios(
 
 	sp->mcr &= ~UART_MCR_AFE;
 
-	if(termios->c_cflag & CRTSCTS) {
+	if (termios->c_cflag & CRTSCTS) {
 		sp->mcr |= UART_MCR_AFE;
 		sp->mcr |= UART_MCR_RTS;
 	}
@@ -2737,34 +2665,34 @@ wch_ser_set_termios(
 
 	sp->port.read_status_mask = UART_LSR_OE | UART_LSR_THRE | UART_LSR_DR;
 
-	if(termios->c_iflag & INPCK) {
+	if (termios->c_iflag & INPCK) {
 		sp->port.read_status_mask |= UART_LSR_FE | UART_LSR_PE;
 	}
 
-	if(termios->c_iflag & (BRKINT | PARMRK)) {
+	if (termios->c_iflag & (BRKINT | PARMRK)) {
 		sp->port.read_status_mask |= UART_LSR_BI;
 	}
 
 	sp->port.ignore_status_mask = 0;
 
-	if(termios->c_iflag & IGNPAR) {
+	if (termios->c_iflag & IGNPAR) {
 		sp->port.ignore_status_mask |= UART_LSR_PE | UART_LSR_FE;
 	}
 
-	if(termios->c_iflag & IGNBRK) {
+	if (termios->c_iflag & IGNBRK) {
 		sp->port.ignore_status_mask |= UART_LSR_BI;
 
-		if(termios->c_iflag & IGNPAR) {
+		if (termios->c_iflag & IGNPAR) {
 			sp->port.ignore_status_mask |= UART_LSR_OE;
 		}
 	}
 
-	if((termios->c_cflag & CREAD) == 0) {
+	if ((termios->c_cflag & CREAD) == 0) {
 		sp->port.ignore_status_mask |= UART_LSR_DR;
 	}
 
 	sp->ier &= ~UART_IER_MSI;
-	if(WCH_ENABLE_MS(&sp->port, termios->c_cflag)) {
+	if (WCH_ENABLE_MS(&sp->port, termios->c_cflag)) {
 		sp->ier |= UART_IER_MSI;
 	}
 
@@ -2786,8 +2714,6 @@ wch_ser_set_termios(
 	spin_unlock_irqrestore(&sp->port.lock, flags);
 }
 
-
-
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0))
 static void wch_ser_timeout(unsigned long data)
 {
@@ -2801,7 +2727,7 @@ static void wch_ser_timeout(struct timer_list *t)
 	unsigned int iir;
 	iir = READ_UART_IIR(sp);
 
-	if(!(iir & UART_IIR_NO_INT)) {
+	if (!(iir & UART_IIR_NO_INT)) {
 		spin_lock(&sp->port.lock);
 		ser_handle_port(sp, iir);
 		spin_unlock(&sp->port.lock);
@@ -2812,7 +2738,6 @@ static void wch_ser_timeout(struct timer_list *t)
 
 	mod_timer(&sp->timer, jiffies + timeout);
 }
-
 
 static _INLINE_ void
 ser_receive_chars(
@@ -2831,47 +2756,47 @@ ser_receive_chars(
 		flag = TTY_NORMAL;
 		sp->port.icount.rx++;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2,4,18))
-		if(unlikely(lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE)))
+		if (unlikely(lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE)))
 #else
-		if(lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE))
+		if (lsr & (UART_LSR_BI | UART_LSR_PE | UART_LSR_FE | UART_LSR_OE))
 #endif
 		{
-			if(lsr & UART_LSR_BI) {
+			if (lsr & UART_LSR_BI) {
 				lsr &= ~(UART_LSR_FE | UART_LSR_PE);
 				sp->port.icount.brk++;
 
-				if(ser_handle_break(&sp->port)) {
+				if (ser_handle_break(&sp->port)) {
 					goto ignore_char;
 				}
-			} else if(lsr & UART_LSR_PE) {
+			} else if (lsr & UART_LSR_PE) {
 				sp->port.icount.parity++;
-			} else if(lsr & UART_LSR_FE) {
+			} else if (lsr & UART_LSR_FE) {
 				sp->port.icount.frame++;
 			}
 
-			if(lsr & UART_LSR_OE) {
+			if (lsr & UART_LSR_OE) {
 				sp->port.icount.overrun++;
 			}
 
 			lsr &= sp->port.read_status_mask;
 
 
-			if(lsr & UART_LSR_BI) {
+			if (lsr & UART_LSR_BI) {
 				flag = TTY_BREAK;
-			} else if(lsr & UART_LSR_PE) {
+			} else if (lsr & UART_LSR_PE) {
 				flag = TTY_PARITY;
-			} else if(lsr & UART_LSR_FE) {
+			} else if (lsr & UART_LSR_FE) {
 				flag = TTY_FRAME;
 			}
 		}
 
 
-		if((I_IXOFF(tty)) || I_IXON(tty)) {
-			if(ch == START_CHAR(tty)) {
+		if ((I_IXOFF(tty)) || I_IXON(tty)) {
+			if (ch == START_CHAR(tty)) {
 				tty->stopped = 0;
 				wch_ser_start_tx(&sp->port, 1);
 				goto ignore_char;
-			} else if(ch == STOP_CHAR(tty)) {
+			} else if (ch == STOP_CHAR(tty)) {
 				tty->stopped = 1;
 				wch_ser_stop_tx(&sp->port, 1);
 				goto ignore_char;
@@ -2883,11 +2808,11 @@ ser_receive_chars(
 ignore_char:
 		lsr = READ_UART_LSR(sp);
 
-		if(lsr == 0xff) {
+		if (lsr == 0xff) {
 			lsr = 0x01;
 		}
 
-	} while(lsr & (UART_LSR_DR | UART_LSR_BI) && (max_count-- > 0));
+	} while (lsr & (UART_LSR_DR | UART_LSR_BI) && (max_count-- > 0));
 
 	spin_unlock(&sp->port.lock);
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 13))
@@ -2899,7 +2824,6 @@ ignore_char:
 	*status = lsr;
 }
 
-
 static _INLINE_ void
 ser_transmit_chars(
     struct wch_ser_port *sp
@@ -2908,26 +2832,26 @@ ser_transmit_chars(
 	struct circ_buf *xmit = &sp->port.info->xmit;
 	int count;
 
-	if((!sp) || (!sp->port.iobase)) {
+	if ((!sp) || (!sp->port.iobase)) {
 		return;
 	}
 
-	if(!sp->port.info) {
+	if (!sp->port.info) {
 		return;
 	}
 
-	if(!xmit) {
+	if (!xmit) {
 		return;
 	}
 
-	if(sp->port.x_char) {
+	if (sp->port.x_char) {
 		WRITE_UART_TX(sp, sp->port.x_char);
 		sp->port.icount.tx++;
 		sp->port.x_char = 0;
 		return;
 	}
 
-	if(ser_circ_empty(xmit) || ser_tx_stopped(&sp->port)) {
+	if (ser_circ_empty(xmit) || ser_tx_stopped(&sp->port)) {
 		wch_ser_stop_tx(&sp->port, 0);
 		return;
 	}
@@ -2939,13 +2863,13 @@ ser_transmit_chars(
 		xmit->tail = (xmit->tail + 1) & (WCH_UART_XMIT_SIZE - 1);
 		sp->port.icount.tx++;
 
-		if(ser_circ_empty(xmit)) {
+		if (ser_circ_empty(xmit)) {
 			break;
 		}
 
-	} while(--count > 0);
+	} while (--count > 0);
 
-	if(ser_circ_chars_pending(xmit) < WAKEUP_CHARS) {
+	if (ser_circ_chars_pending(xmit) < WAKEUP_CHARS) {
 		ser_write_wakeup(&sp->port);
 	}
 	/*
@@ -2956,40 +2880,38 @@ ser_transmit_chars(
 	*/
 }
 
-
 static _INLINE_ void
 ser_check_modem_status(
     struct wch_ser_port *sp,
     unsigned char status
 )
 {
-	if((status & UART_MSR_ANY_DELTA) == 0) {
+	if ((status & UART_MSR_ANY_DELTA) == 0) {
 		return;
 	}
 
-	if(!sp->port.info) {
+	if (!sp->port.info) {
 		return;
 	}
 
-	if(status & UART_MSR_TERI) {
+	if (status & UART_MSR_TERI) {
 		sp->port.icount.rng++;
 	}
 
-	if(status & UART_MSR_DDSR) {
+	if (status & UART_MSR_DDSR) {
 		sp->port.icount.dsr++;
 	}
 
-	if(status & UART_MSR_DDCD) {
+	if (status & UART_MSR_DDCD) {
 		ser_handle_dcd_change(&sp->port, status & UART_MSR_DCD);
 	}
 
-	if(status & UART_MSR_DCTS) {
+	if (status & UART_MSR_DCTS) {
 		ser_handle_cts_change(&sp->port, status & UART_MSR_CTS);
 	}
 
 	wake_up_interruptible(&sp->port.info->delta_msr_wait);
 }
-
 
 static _INLINE_ void
 ser_handle_port(
@@ -3000,25 +2922,24 @@ ser_handle_port(
 	unsigned char lsr = READ_UART_LSR(sp);
 	unsigned char msr = 0;
 
-	if(lsr == 0xff) {
+	if (lsr == 0xff) {
 		lsr = 0x01;
 	}
 
-	if((iir == UART_IIR_RLSI) || (iir == UART_IIR_CTO) || (iir == UART_IIR_RDI)) {
+	if ((iir == UART_IIR_RLSI) || (iir == UART_IIR_CTO) || (iir == UART_IIR_RDI)) {
 		ser_receive_chars(sp, &lsr);
 	}
 
-	if((iir == UART_IIR_THRI) && (lsr & UART_LSR_THRE)) {
+	if ((iir == UART_IIR_THRI) && (lsr & UART_LSR_THRE)) {
 		ser_transmit_chars(sp);
 	}
 
 	msr = READ_UART_MSR(sp);
 
-	if(msr & UART_MSR_ANY_DELTA) {
+	if (msr & UART_MSR_ANY_DELTA) {
 		ser_check_modem_status(sp, msr);
 	}
 }
-
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 static struct tty_operations wch_tty_ops = {
@@ -3062,7 +2983,7 @@ wch_ser_register_driver(
 	drv->state = kmalloc(sizeof(struct ser_state) * drv->nr, GFP_KERNEL);
 	ret = -ENOMEM;
 
-	if(!drv->state) {
+	if (!drv->state) {
 		printk("WCH Error: Allocate memory fail !\n\n");
 		goto out;
 	}
@@ -3074,7 +2995,7 @@ wch_ser_register_driver(
 #else
 	normal = &drv->tty_driver;
 #endif
-	if(!normal) {
+	if (!normal) {
 		printk("WCH Error: Allocate tty driver fail !\n\n");
 		goto out;
 	}
@@ -3124,9 +3045,9 @@ wch_ser_register_driver(
 	normal->wait_until_sent = ser_wait_until_sent;
 #endif
 
-	for(i = 0; i < drv->nr; i++) {
+	for (i = 0; i < drv->nr; i++) {
 		struct ser_state *state = drv->state + i;
-		if(!state) {
+		if (!state) {
 			ret = -1;
 			printk("WCH Error: Memory error !\n\n");
 			goto out;
@@ -3150,13 +3071,13 @@ wch_ser_register_driver(
 	kref_init(&normal->kref);
 #endif
 	ret = tty_register_driver(normal);
-	if(ret < 0) {
+	if (ret < 0) {
 		printk("WCH Error: Register tty driver fail !\n\n");
 		goto out;
 	}
 
 out:
-	if(ret < 0) {
+	if (ret < 0) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 		put_tty_driver(normal);
 #endif
@@ -3165,7 +3086,6 @@ out:
 
 	return (ret);
 }
-
 
 extern void
 wch_ser_unregister_driver(
@@ -3179,7 +3099,7 @@ wch_ser_unregister_driver(
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0))
 	normal = drv->tty_driver;
-	if(!normal) {
+	if (!normal) {
 		return;
 	}
 
@@ -3189,17 +3109,16 @@ wch_ser_unregister_driver(
 
 #else
 	normal = &drv->tty_driver;
-	if(!normal) {
+	if (!normal) {
 		return;
 	}
 
 	tty_unregister_driver(normal);
 #endif
-	if(drv->state) {
+	if (drv->state) {
 		kfree(drv->state);
 	}
 }
-
 
 static void
 wch_ser_request_io(
@@ -3207,7 +3126,7 @@ wch_ser_request_io(
 )
 {
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
-	switch(sp->port.iotype) {
+	switch (sp->port.iotype) {
 	case WCH_UPIO_PORT:
 		request_region(sp->port.iobase, WCH_SER_ADDRESS_LENGTH, "wch_ser");
 		break;
@@ -3218,7 +3137,6 @@ wch_ser_request_io(
 	}
 }
 
-
 static void
 wch_ser_configure_port(
     struct ser_driver *drv,
@@ -3227,13 +3145,13 @@ wch_ser_configure_port(
 )
 {
 	unsigned long flags;
-	if(!port->iobase) {
+	if (!port->iobase) {
 		return;
 	}
 
 	flags = WCH_UART_CONFIG_TYPE;
 
-	if(port->type != PORT_UNKNOWN) {
+	if (port->type != PORT_UNKNOWN) {
 		wch_ser_request_io(port);
 
 		spin_lock_irqsave(&port->lock, flags);
@@ -3242,7 +3160,6 @@ wch_ser_configure_port(
 		spin_unlock_irqrestore(&port->lock, flags);
 	}
 }
-
 
 static int
 wch_ser_add_one_port(
@@ -3254,7 +3171,7 @@ wch_ser_add_one_port(
 
 	int ret = 0;
 
-	if(port->line >= drv->nr) {
+	if (port->line >= drv->nr) {
 		return -EINVAL;
 	}
 
@@ -3262,7 +3179,7 @@ wch_ser_add_one_port(
 
 	down(&ser_port_sem);
 
-	if(state->port) {
+	if (state->port) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -3281,7 +3198,6 @@ out:
 	return ret;
 }
 
-
 extern int
 wch_ser_register_ports(
     struct ser_driver *drv
@@ -3293,16 +3209,16 @@ wch_ser_register_ports(
 #if WCH_DBG
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
-	for(i = 0; i < wch_ser_port_total_cnt; i++) {
+	for (i = 0; i < wch_ser_port_total_cnt; i++) {
 		struct wch_ser_port *sp = &wch_ser_table[i];
 
-		if(!sp) {
+		if (!sp) {
 			return -1;
 		}
 
 		sp->port.line = i;
 #if (LINUX_VERSION_CODE <= KERNEL_VERSION(3, 8, 0))
-		if(sp->port.iobase)
+		if (sp->port.iobase)
 #endif
 		{
 
@@ -3318,7 +3234,7 @@ wch_ser_register_ports(
 
 			ret = wch_ser_add_one_port(drv, &sp->port);
 
-			if(ret != 0) {
+			if (ret != 0) {
 				return ret;
 			}
 		}
@@ -3329,7 +3245,6 @@ wch_ser_register_ports(
 	return 0;
 }
 
-
 static void
 wch_ser_release_io(
     struct ser_port *port
@@ -3337,7 +3252,7 @@ wch_ser_release_io(
 {
 	struct wch_ser_port *sp = (struct wch_ser_port *)port;
 
-	switch(sp->port.iotype) {
+	switch (sp->port.iotype) {
 	case WCH_UPIO_PORT:
 		release_region(sp->port.iobase, WCH_SER_ADDRESS_LENGTH);
 		break;
@@ -3348,7 +3263,6 @@ wch_ser_release_io(
 	}
 }
 
-
 static void
 wch_ser_unconfigure_port(
     struct ser_driver *drv,
@@ -3357,7 +3271,7 @@ wch_ser_unconfigure_port(
 {
 	struct ser_port *port = state->port;
 	struct ser_info *info = state->info;
-	if(info && info->tty) {
+	if (info && info->tty) {
 		tty_hangup(info->tty);
 	}
 
@@ -3365,20 +3279,19 @@ wch_ser_unconfigure_port(
 
 	state->info = NULL;
 
-	if(port->type != PORT_UNKNOWN) {
+	if (port->type != PORT_UNKNOWN) {
 		wch_ser_release_io(port);
 	}
 
 	port->type = PORT_UNKNOWN;
 
-	if(info) {
+	if (info) {
 		tasklet_kill(&info->tlet);
 		kfree(info);
 	}
 
 	up(&state->sem);
 }
-
 
 static int
 wch_ser_remove_one_port(
@@ -3388,7 +3301,7 @@ wch_ser_remove_one_port(
 {
 	struct ser_state *state = drv->state + port->line;
 
-	if(state->port != port) {
+	if (state->port != port) {
 		printk("WCH Info : Removing wrong port: %p != %p\n\n", state->port, port);
 	}
 
@@ -3404,9 +3317,7 @@ wch_ser_remove_one_port(
 	return 0;
 }
 
-
-extern
-void
+extern void
 wch_ser_unregister_ports(
     struct ser_driver *drv
 )
@@ -3417,17 +3328,16 @@ wch_ser_unregister_ports(
 	printk("%s : %s\n", __FILE__, __FUNCTION__);
 #endif
 
-	for(i = 0; i < wch_ser_port_total_cnt; i++) {
+	for (i = 0; i < wch_ser_port_total_cnt; i++) {
 		struct wch_ser_port *sp = &wch_ser_table[i];
 
-		if(sp->port.iobase) {
+		if (sp->port.iobase) {
 			wch_ser_remove_one_port(drv, &sp->port);
 		}
 	}
 }
 
-extern
-int
+extern int
 wch_ser_interrupt(
     struct wch_board *sb,
     struct wch_ser_port *first_sp
@@ -3444,18 +3354,18 @@ wch_ser_interrupt(
 
 	max = sb->ser_ports;
 
-	if((first_sp->port.port_flag & PORTFLAG_REMAP) == PORTFLAG_REMAP) { // CH352_2S CH352_1S1P
-		while(1) {
-			for(i = 0; i < max; i++) {
+	if ((first_sp->port.port_flag & PORTFLAG_REMAP) == PORTFLAG_REMAP) { // CH352_2S CH352_1S1P
+		while (1) {
+			for (i = 0; i < max; i++) {
 				sp = first_sp + i;
 
-				if(!sp->port.iobase) {
+				if (!sp->port.iobase) {
 					continue;
 				}
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3464,22 +3374,22 @@ wch_ser_interrupt(
 				}
 			}
 
-			if(pass_counter++ > INTERRUPT_COUNT) {
+			if (pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH353_4S)) { // CH353_4S
-		while(1) {
+	} else if ((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH353_4S)) { // CH353_4S
+		while (1) {
 			irqbits = READ_INTERRUPT_VECTOR_BYTE(first_sp) & first_sp->port.vector_mask;
-			if(irqbits == 0x0000) {
+			if (irqbits == 0x0000) {
 				break;
 			}
 
-			for(i = 0, bits = 1; i < max; i++, bits <<= 1) {
-				if(i == 0x02) {
+			for (i = 0, bits = 1; i < max; i++, bits <<= 1) {
+				if (i == 0x02) {
 					bits <<= 2;
 				}
-				if(!(bits & irqbits)) {
+				if (!(bits & irqbits)) {
 					continue;
 				}
 
@@ -3487,7 +3397,7 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3496,19 +3406,19 @@ wch_ser_interrupt(
 				}
 			}
 
-			if(pass_counter++ > INTERRUPT_COUNT) {
+			if (pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH359_16S)) { // CH359_16S
-		while(1) {
+	} else if ((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH359_16S)) { // CH359_16S
+		while (1) {
 			irqbits = READ_INTERRUPT_VECTOR_WORD(first_sp) & first_sp->port.vector_mask;
-			if(irqbits == 0x0000) {
+			if (irqbits == 0x0000) {
 				break;
 			}
 
-			for(i = 0, bits = 1; i < max; i++, bits <<= 1) {
-				if(!(bits & irqbits)) {
+			for (i = 0, bits = 1; i < max; i++, bits <<= 1) {
+				if (!(bits & irqbits)) {
 					continue;
 				}
 
@@ -3516,7 +3426,7 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3525,35 +3435,35 @@ wch_ser_interrupt(
 				}
 			}
 
-			if(pass_counter++ > INTERRUPT_COUNT) {
+			if (pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) ||
-	          (first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_8S)) { // CH384_8S CH384_28S
-		while(1) {
+	} else if ((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) ||
+	           (first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCIE && first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_8S)) { // CH384_8S CH384_28S
+		while (1) {
 			irqbits = READ_INTERRUPT_VECTOR_DWORD(first_sp) & first_sp->port.vector_mask;
 
-			if((irqbits & 0x80000000) != 0 &&
-			   (irqbits & 0x40000000) != 0 &&
-			   (irqbits & 0x20000000) != 0 &&
-			   (irqbits & 0x00000100) == 0 &&
-			   (irqbits & 0x00000200) == 0 &&
-			   (irqbits & 0x00000400) == 0 &&
-			   (irqbits & 0x00000800) == 0) {
+			if ((irqbits & 0x80000000) != 0 &&
+			    (irqbits & 0x40000000) != 0 &&
+			    (irqbits & 0x20000000) != 0 &&
+			    (irqbits & 0x00000100) == 0 &&
+			    (irqbits & 0x00000200) == 0 &&
+			    (irqbits & 0x00000400) == 0 &&
+			    (irqbits & 0x00000800) == 0) {
 				break;
 			}
 
 			/* handle CH438 #3 */
-			if((irqbits & 0x80000000) == 0) {
+			if ((irqbits & 0x80000000) == 0) {
 				sp = first_sp + 0x14;
 				ch438irqbits = READ_INTERRUPT_VECTOR_BYTE(sp) & sp->port.vector_mask;
-				if(ch438irqbits != 0) {
-					for(i = 0; i < 0x08; i++) {
-						if(ch438irqbits & (1 << i)) {
+				if (ch438irqbits != 0) {
+					for (i = 0; i < 0x08; i++) {
+						if (ch438irqbits & (1 << i)) {
 							sp += i;
 							iir = READ_UART_IIR(sp) & 0x0f;
-							if(iir & UART_IIR_NO_INT) {
+							if (iir & UART_IIR_NO_INT) {
 								continue;
 							} else {
 								spin_lock(&sp->port.lock);
@@ -3565,15 +3475,15 @@ wch_ser_interrupt(
 				}
 			}
 			/* handle CH438 #2 */
-			if((irqbits & 0x40000000) == 0) {
+			if ((irqbits & 0x40000000) == 0) {
 				sp = first_sp + 0x0C;
 				ch438irqbits = READ_INTERRUPT_VECTOR_BYTE(sp) & sp->port.vector_mask;
-				if(ch438irqbits != 0) {
-					for(i = 0; i < 0x08; i++) {
-						if(ch438irqbits & (1 << i)) {
+				if (ch438irqbits != 0) {
+					for (i = 0; i < 0x08; i++) {
+						if (ch438irqbits & (1 << i)) {
 							sp += i;
 							iir = READ_UART_IIR(sp) & 0x0f;
-							if(iir & UART_IIR_NO_INT) {
+							if (iir & UART_IIR_NO_INT) {
 								continue;
 							} else {
 								spin_lock(&sp->port.lock);
@@ -3585,21 +3495,21 @@ wch_ser_interrupt(
 				}
 			}
 			/* handle CH438 #1 */
-			if((irqbits & 0x20000000) == 0) {
+			if ((irqbits & 0x20000000) == 0) {
 				/* CH384_28S */
-				if(first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) {
+				if (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH384_28S) {
 					sp = first_sp + 0x04;
 				} else {
 					/* CH384_8S */
 					sp = first_sp;
 				}
 				ch438irqbits = READ_INTERRUPT_VECTOR_BYTE(sp) & sp->port.vector_mask;
-				if(ch438irqbits != 0) {
-					for(i = 0; i < 0x08; i++) {
-						if(ch438irqbits & (1 << i)) {
+				if (ch438irqbits != 0) {
+					for (i = 0; i < 0x08; i++) {
+						if (ch438irqbits & (1 << i)) {
 							sp += i;
 							iir = READ_UART_IIR(sp) & 0x0f;
-							if(iir & UART_IIR_NO_INT) {
+							if (iir & UART_IIR_NO_INT) {
 								continue;
 							} else {
 								spin_lock(&sp->port.lock);
@@ -3610,11 +3520,11 @@ wch_ser_interrupt(
 					}
 				}
 			}
-			if((irqbits & 0x00000100) == 0x00000100) {
+			if ((irqbits & 0x00000100) == 0x00000100) {
 				sp = first_sp;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3622,11 +3532,11 @@ wch_ser_interrupt(
 					spin_unlock(&sp->port.lock);
 				}
 			}
-			if((irqbits & 0x00000200) == 0x00000200) {
+			if ((irqbits & 0x00000200) == 0x00000200) {
 				sp = first_sp + 0x01;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3634,11 +3544,11 @@ wch_ser_interrupt(
 					spin_unlock(&sp->port.lock);
 				}
 			}
-			if((irqbits & 0x00000400) == 0x00000400) {
+			if ((irqbits & 0x00000400) == 0x00000400) {
 				sp = first_sp + 0x02;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3646,11 +3556,11 @@ wch_ser_interrupt(
 					spin_unlock(&sp->port.lock);
 				}
 			}
-			if((irqbits & 0x00000800) == 0x00000800) {
+			if ((irqbits & 0x00000800) == 0x00000800) {
 				sp = first_sp + 0x03;
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3659,29 +3569,29 @@ wch_ser_interrupt(
 				}
 			}
 
-			if(pass_counter++ > INTERRUPT_COUNT) {
+			if (pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
-	} else if((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH365_32S)) {
-		while(1) {
-			if((inb(first_sp->port.chip_iobase + 0xF8) & 0x04) != 0x04) {
+	} else if ((first_sp->port.pb_info.vendor_id == VENDOR_ID_WCH_PCI) && (first_sp->port.pb_info.device_id == DEVICE_ID_WCH_CH365_32S)) {
+		while (1) {
+			if ((inb(first_sp->port.chip_iobase + 0xF8) & 0x04) != 0x04) {
 				break;
 			}
 
 			irqbits = inb(first_sp->port.chip_iobase) & first_sp->port.vector_mask;
-			if(irqbits == 0xFF) {
+			if (irqbits == 0xFF) {
 				break;
 			}
 
-			if((irqbits & 0x00000010) == 0) { // first ch438 irq
-				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
+			if ((irqbits & 0x00000010) == 0) { // first ch438 irq
+				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i;
 					ch438irqbits = readb(sp->port.board_membase + 0x100 + 0x4F) & sp->port.vector_mask;
-					if(ch438irqbits == 0x00000000) {
+					if (ch438irqbits == 0x00000000) {
 						break;
 					}
-					if(!(bits & ch438irqbits)) {
+					if (!(bits & ch438irqbits)) {
 						continue;
 					} else {
 						break;
@@ -3690,7 +3600,7 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3698,14 +3608,14 @@ wch_ser_interrupt(
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			} else if((irqbits & 0x00000020) == 0) {
-				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
+			} else if ((irqbits & 0x00000020) == 0) {
+				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i + 0x08;
 					ch438irqbits = readb(sp->port.board_membase + 0x180 + 0x4F) & sp->port.vector_mask;
-					if(ch438irqbits == 0x00000000) {
+					if (ch438irqbits == 0x00000000) {
 						break;
 					}
-					if(!(bits & ch438irqbits)) {
+					if (!(bits & ch438irqbits)) {
 						continue;
 					} else {
 						break;
@@ -3713,7 +3623,7 @@ wch_ser_interrupt(
 				}
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3721,14 +3631,14 @@ wch_ser_interrupt(
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			} else if((irqbits & 0x00000040) == 0) {
-				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
+			} else if ((irqbits & 0x00000040) == 0) {
+				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i + 0x10;
 					ch438irqbits = readb(sp->port.board_membase + 0x200 + 0x4F) & sp->port.vector_mask;
-					if(ch438irqbits == 0x00000000) {
+					if (ch438irqbits == 0x00000000) {
 						break;
 					}
-					if(!(bits & ch438irqbits)) {
+					if (!(bits & ch438irqbits)) {
 						continue;
 					} else {
 						break;
@@ -3736,7 +3646,7 @@ wch_ser_interrupt(
 				}
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3744,14 +3654,14 @@ wch_ser_interrupt(
 					spin_unlock(&sp->port.lock);
 				}
 				outb(inb(sp->port.chip_iobase + 0xF8) & 0xFB, sp->port.chip_iobase + 0xF8);
-			} else if((irqbits & 0x00000080) == 0) {
-				for(i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
+			} else if ((irqbits & 0x00000080) == 0) {
+				for (i = 0, bits = 1; i < 0x08; i++, bits <<= 1) {
 					sp = first_sp + i + 0x18;
 					ch438irqbits = readb(sp->port.board_membase + 0x280 + 0x4F) & sp->port.vector_mask;
-					if(ch438irqbits == 0x00000000) {
+					if (ch438irqbits == 0x00000000) {
 						break;
 					}
-					if(!(bits & ch438irqbits)) {
+					if (!(bits & ch438irqbits)) {
 						continue;
 					} else {
 						break;
@@ -3759,7 +3669,7 @@ wch_ser_interrupt(
 				}
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3771,19 +3681,19 @@ wch_ser_interrupt(
 				break;
 			}
 
-			if(pass_counter++ > INTERRUPT_COUNT) {
+			if (pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}
 	} else { // CH353_2S1P CH353_2S1PAR CH355_4S CH356_4S1P CH356_8S CH358_4S1P CH358_8S CH382_2S1P CH384_4S1P
-		while(1) {
+		while (1) {
 			irqbits = READ_INTERRUPT_VECTOR_BYTE(first_sp) & first_sp->port.vector_mask;
-			if(irqbits == 0x0000) {
+			if (irqbits == 0x0000) {
 				break;
 			}
 
-			for(i = 0, bits = 1; i < max; i++, bits <<= 1) {
-				if(!(bits & irqbits)) {
+			for (i = 0, bits = 1; i < max; i++, bits <<= 1) {
+				if (!(bits & irqbits)) {
 					continue;
 				}
 
@@ -3791,7 +3701,7 @@ wch_ser_interrupt(
 
 				iir = READ_UART_IIR(sp) & 0x0f;
 
-				if(iir & UART_IIR_NO_INT) {
+				if (iir & UART_IIR_NO_INT) {
 					continue;
 				} else {
 					spin_lock(&sp->port.lock);
@@ -3800,7 +3710,7 @@ wch_ser_interrupt(
 				}
 			}
 
-			if(pass_counter++ > INTERRUPT_COUNT) {
+			if (pass_counter++ > INTERRUPT_COUNT) {
 				break;
 			}
 		}


### PR DESCRIPTION
使用CH384+CH438实现非8S或28S应用时，可参考说明文档修改为实际串口数量。
使用非22.1184MHz晶体时，可参考说明文档修改为实际选用晶体频率。